### PR TITLE
Fix footer display issue on all pages

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -38,7 +38,7 @@ export default function Footer() {
 	const code = marketingCode || parsedFrontendCode;
 
 	return (
-		<div className="md:flex max-md:grid-rows-2 max-md:justify-items-center md:px-12 pb-12 pt-6 bg-layout-footer text-layout-primary">
+		<footer className="md:flex max-md:grid-rows-2 max-md:justify-items-center md:px-12 pb-12 pt-6 bg-layout-footer text-layout-primary mt-auto">
 			<div className="flex-1 justify-start text-center md:text-left">
 				<SubmitIssue />
 				{code && (
@@ -65,7 +65,7 @@ export default function Footer() {
 					<FooterButton link={SOCIAL.Twitter} text="Twitter" icon={faXTwitter} />
 				</li>
 			</ul>
-		</div>
+		</footer>
 	);
 }
 

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -12,17 +12,18 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 	const isMainnet = useIsMainnet();
 
 	return (
-		<div>
+		<div className="flex flex-col min-h-screen">
 			<Head>
 				<title>dEURO - Home</title>
 			</Head>
 
 			<Navbar />
 
-			<div className="h-main pt-24">
-				<main className="block mb-16 mx-auto max-w-6xl space-y-8 px-4 md:px-8 2xl:max-w-7xl min-h-content">{children}</main>
-				<Footer />
-			</div>
+			<main className="flex-1 pt-24 pb-16">
+				<div className="mx-auto max-w-6xl space-y-8 px-4 md:px-8 2xl:max-w-7xl">{children}</div>
+			</main>
+			
+			<Footer />
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary
- Fixed footer being cut off on pages like /swap and /equity
- Restructured layout to ensure footer is always fully visible

## Problem
The footer was partially hidden/cut off at the bottom of the viewport on certain pages, making it impossible to see social links and other footer content.

## Solution
- Changed Layout component to use flexbox layout with `min-h-screen`
- Moved Footer component outside of content container
- Added `flex-1` to main content area to push footer down
- Changed Footer wrapper from div to semantic footer element
- Added `mt-auto` to Footer for proper positioning

## Testing
- [x] Footer is fully visible on /swap page
- [x] Footer is fully visible on /equity page
- [x] Footer is fully visible on all other pages
- [x] Footer stays at bottom when content is short
- [x] Footer moves down when content is long

## Screenshots
Before: Footer was cut off at the bottom
After: Footer is now fully visible

Fixes the footer display issue reported by user.