### PR TITLE
Remove false lock time information from Savings

### DIFF
--- a/components/PageSavings/SavingsDetailsCard.tsx
+++ b/components/PageSavings/SavingsDetailsCard.tsx
@@ -7,10 +7,9 @@ interface Props {
 	change: bigint;
 	direction: boolean;
 	interest: bigint;
-	locktime: bigint;
 }
 
-export default function SavingsDetailsCard({ balance, change, direction, interest, locktime }: Props) {
+export default function SavingsDetailsCard({ balance, change, direction, interest }: Props) {
 	const { t } = useTranslation();
 
 	return (
@@ -33,19 +32,6 @@ export default function SavingsDetailsCard({ balance, change, direction, interes
 				<div className="flex font-bold">
 					<div className="flex-1">{t("savings.resulting_balance")}</div>
 					<div className="">{formatCurrency(formatUnits(balance + change + interest, 18))} {TOKEN_SYMBOL}</div>
-				</div>
-
-				<div className="flex mt-8">
-					<div className={`flex-1`}>
-						{t("savings.when_saving_additional_funds_your_balance_will_be_locked")}
-						<span className="font-semibold">
-							{locktime > 0
-								? `${t("savings.your_funds_are_still_locked_for", { hours: formatCurrency(
-										(parseFloat(locktime.toString()) / 60 / 60).toString()
-								  )})}`
-								: ""}
-						</span>
-					</div>
 				</div>
 			</div>
 		</AppCard>

--- a/components/PageSavings/SavingsInteractionCard.tsx
+++ b/components/PageSavings/SavingsInteractionCard.tsx
@@ -207,7 +207,6 @@ export default function SavingsInteractionCard() {
 				change={isLoaded ? change : 0n}
 				direction={direction}
 				interest={isLoaded ? userSavingsInterest : 0n}
-				locktime={userSavingsLocktime}
 			/>
 		</section>
 	);

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -572,8 +572,6 @@
         "withdrawn_to_your_wallet": "Auf deine Wallet ausgezahlt",
         "interest_to_be_collected": "Auszahlbare Zinsen",
         "resulting_balance": "Resultierender Kontostand",
-        "when_saving_additional_funds_your_balance_will_be_locked": "Beim Einzahlen weiterer Gelder wird dein Guthaben gesperrt, bis die Zinsen anfallen, was bis zu drei Tage dauern kann. Diese Regel soll verhindern, dass Gelder eingezahlt werden, die für Transaktionen gedacht sind.",
-        "your_funds_are_still_locked_for": "Dein Guthaben ist noch für {{hours}} Stunden gesperrt.",
         "date": "Datum",
         "saver": "Sparer",
         "amount": "Betrag",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -572,8 +572,6 @@
         "withdrawn_to_your_wallet": "Withdrawn to your wallet",
         "interest_to_be_collected": "Interest to be collected",
         "resulting_balance": "Resulting Balance",
-        "when_saving_additional_funds_your_balance_will_be_locked": "When saving additional funds, your balance will be locked until interest starts accruing, which can take up to three days. This rules serves to disincentivize the saving of funds held for transactional purposes.",
-        "your_funds_are_still_locked_for": "Your funds are still locked for {{hours}} hours.",
         "date": "Date",
         "saver": "Saver",
         "amount": "Amount",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -572,8 +572,6 @@
         "withdrawn_to_your_wallet": "Retirado a su monedero",
         "interest_to_be_collected": "Intereses pendientes de cobro",
         "resulting_balance": "Saldo resultante",
-        "when_saving_additional_funds_your_balance_will_be_locked": "Al guardar fondos adicionales, su saldo quedará bloqueado hasta que comiencen a generarse intereses, lo que puede tardar hasta tres días. Esta norma sirve para desincentivar el ahorro de fondos destinados a transacciones.",
-        "your_funds_are_still_locked_for": "Sus fondos aún están bloqueados durante {{hours}} horas.",
         "date": "Fecha",
         "saver": "Ahorro",
         "amount": "Monto",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -572,8 +572,6 @@
         "withdrawn_to_your_wallet": "Retrait sur votre portefeuille",
         "interest_to_be_collected": "Intérêts à collecter",
         "resulting_balance": "Solde résultant",
-        "when_saving_additional_funds_your_balance_will_be_locked": "Lorsque vous enregistrez des fonds supplémentaires, votre solde sera bloqué jusqu'au début de la capitalisation des intérêts, ce qui peut prendre jusqu'à trois jours. Cette règle vise à décourager l'épargne de fonds détenus à des fins transactionnelles.",
-        "your_funds_are_still_locked_for": "Vos fonds sont encore bloqués pendant {{hours}} heures.",
         "date": "Date",
         "saver": "Épargne",
         "amount": "Montant",


### PR DESCRIPTION
## Summary
The savings module incorrectly displayed a warning about a 3-day lock period that does not actually exist. This was confusing for users.

## Changes
- Removed false information about 3-day lock period from SavingsDetailsCard
- Removed locktime parameter and related logic  
- Users can now see accurate information about immediate access to savings

## Testing
- [x] Changes have been tested locally
- [x] No console errors
- [x] UI displays correctly without lock warning
- [x] Savings functionality works as expected