### PR TITLE
Fix repayment calculation to compensate for smart contract reserve bug

### DIFF
--- a/components/PageMint/BorrowedManageSection.tsx
+++ b/components/PageMint/BorrowedManageSection.tsx
@@ -224,12 +224,45 @@ export const BorrowedManageSection = () => {
 					args: [BigInt(0), BigInt(0), BigInt(position.price)],
 				});
 			} else {
-				const { loanAmount } = getLoanDetailsByCollateralAndYouGetAmount(position, balanceOf, BigInt(amount));
+				// The smart contract repays in this order:
+				// 1. First pays off interest (no reserve logic applied)
+				// 2. Then pays principal (incorrectly applies 0.9 factor due to reserve bug)
+				// We need to adjust only the principal portion
+				
+				const userInputAmount = BigInt(amount);
+				const currentInterest = interest; // From contract data
+				const reserveRatio = BigInt(position.reserveContribution); // in PPM
+				
+				// Calculate how much of the user's input would go to principal vs interest
+				let principalPortion: bigint;
+				let interestPortion: bigint;
+				
+				if (userInputAmount <= currentInterest) {
+					// User is only paying interest
+					interestPortion = userInputAmount;
+					principalPortion = 0n;
+				} else {
+					// User is paying full interest + some principal
+					interestPortion = currentInterest;
+					principalPortion = userInputAmount - currentInterest;
+				}
+				
+				// Only adjust the principal portion for the reserve bug
+				// The bug: contract multiplies principal payment by (1 - reserveRatio)
+				// To compensate: we divide by (1 - reserveRatio)
+				let adjustedAmount: bigint;
+				if (principalPortion > 0n) {
+					const adjustedPrincipal = (principalPortion * 1_000_000n) / (1_000_000n - reserveRatio);
+					adjustedAmount = interestPortion + adjustedPrincipal;
+				} else {
+					adjustedAmount = interestPortion;
+				}
+				
 				payBackHash = await writeContract(WAGMI_CONFIG, {
 					address: position.position,
 					abi: PositionV2ABI,
 					functionName: "repay",
-					args: [loanAmount],
+					args: [adjustedAmount],
 				});
 			}
 


### PR DESCRIPTION
## Summary
- Fixed repayment calculation in BorrowedManageSection to ensure users pay exactly the amount they input
- The smart contract has a bug where it incorrectly applies the reserve ratio during principal repayment
- This fix adjusts only the principal portion while leaving interest payments unaffected

## Problem
When users attempted to repay 1000 dEURO, only ~900 dEURO was actually deducted from their debt due to the smart contract multiplying the principal payment by (1 - reserveRatio).

## Solution
The fix separates interest and principal portions of the repayment:
1. Interest is paid first without any adjustment
2. Principal portion is adjusted by dividing by (1 - reserveRatio) to compensate for the contract's multiplication
3. Uses the dynamic reserveContribution from each position for accurate calculation

## Test plan
- [x] Tested repayment with 1000 dEURO input - exactly 1000 dEURO is deducted from wallet
- [x] Verified interest is paid correctly without adjustment
- [x] Confirmed principal adjustment works with different reserve ratios
- [ ] Test with various repayment amounts
- [ ] Test partial interest payments
- [ ] Test full loan repayment