### PR TITLE
Fix borrow/pay back button disabled state

### DIFF
--- a/components/PageMint/BorrowedManageSection.tsx
+++ b/components/PageMint/BorrowedManageSection.tsx
@@ -365,7 +365,7 @@ export const BorrowedManageSection = () => {
 					className="text-lg leading-snug !font-extrabold"
 					onClick={isBorrowMore ? handleBorrowMore : handlePayBack}
 					isLoading={isTxOnGoing}
-					disabled={!amount}
+					disabled={!amount || Boolean(error)}
 				>
 					{t(
 						isBorrowMore

--- a/components/PageMint/BorrowedManageSection.tsx
+++ b/components/PageMint/BorrowedManageSection.tsx
@@ -365,12 +365,12 @@ export const BorrowedManageSection = () => {
 					className="text-lg leading-snug !font-extrabold"
 					onClick={isBorrowMore ? handleBorrowMore : handlePayBack}
 					isLoading={isTxOnGoing}
-					disabled={!amount || Boolean(error)}
+					disabled={!amount || !BigInt(amount) || Boolean(error)}
 				>
 					{t(
 						isBorrowMore
 							? "mint.borrow_more"
-							: amount.toString() === debt.toString()
+							: amount && BigInt(amount) && amount.toString() === debt.toString()
 							? "mint.pay_back_and_close"
 							: "mint.pay_back"
 					)}

--- a/components/PageMint/CollateralManageSection.tsx
+++ b/components/PageMint/CollateralManageSection.tsx
@@ -326,7 +326,7 @@ export const CollateralManageSection = () => {
 					className="text-lg leading-snug !font-extrabold"
 					onClick={handleRemove}
 					isLoading={isTxOnGoing}
-					disabled={Boolean(error) || !Boolean(amount)}
+					disabled={!!error || !amount || !BigInt(amount)}
 				>
 					{t(isAdd ? "mint.add_collateral" : "mint.remove_collateral")}
 				</Button>
@@ -335,7 +335,7 @@ export const CollateralManageSection = () => {
 					className="text-lg leading-snug !font-extrabold"
 					onClick={handleAdd}
 					isLoading={isTxOnGoing}
-					disabled={Boolean(error) || !Boolean(amount)}
+					disabled={!!error || !amount || !BigInt(amount)}
 				>
 					{t(isAdd ? "mint.add_collateral" : "mint.remove_collateral")}
 				</Button>

--- a/components/PageSavings/SavingsInteractionSection.tsx
+++ b/components/PageSavings/SavingsInteractionSection.tsx
@@ -23,6 +23,7 @@ import { RootState } from "../../redux/redux.store";
 export default function SavingsInteractionSection() {
 	const { userSavingsBalance, interestToBeCollected, refetchInterest } = useSavingsInterest();
 	const [amount, setAmount] = useState("");
+	const [buttonLabel, setButtonLabel] = useState("");
 	const [isDeposit, setIsDeposit] = useState(true);
 	const [isTxOnGoing, setIsTxOnGoing] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -190,31 +191,37 @@ export default function SavingsInteractionSection() {
 	useEffect(() => {
 		if (!isDeposit) return;
 
-		if (!amount) {
+		if (!amount || !BigInt(amount)) {
 			setError(null);
+			setButtonLabel(t("savings.enter_amount_to_add_savings"));
 			return;
 		}
 
 		if (BigInt(amount) > userBalance) {
 			setError(t("savings.error.insufficient_balance"));
+			setButtonLabel(t("savings.enter_amount_to_add_savings"));
 		} else {
 			setError(null);
+			setButtonLabel(t("savings.start_earning_interest", { rate: rate / 10_000 }));
 		}
-	}, [amount, isDeposit, userBalance]);
+	}, [amount, rate, isDeposit, userBalance]);
 
 	// Withdraw validation
 	useEffect(() => {
 		if (isDeposit) return;
 
-		if (!amount) {
+		if (!amount || !BigInt(amount)) {
 			setError(null);
+			setButtonLabel(t("savings.enter_withdraw_amount"));
 			return;
 		}
 
 		if (BigInt(amount) > userSavingsBalance) {
 			setError(t("savings.error.greater_than_savings"));
+			setButtonLabel(t("savings.enter_withdraw_amount"));
 		} else {
 			setError(null);
+			setButtonLabel(t("savings.withdraw_to_my_wallet"));
 		}
 	}, [amount, isDeposit, userSavingsBalance]);
 
@@ -284,15 +291,9 @@ export default function SavingsInteractionSection() {
 							className="text-lg leading-snug !font-extrabold"
 							onClick={isDeposit ? handleSave : handleWithdraw}
 							isLoading={isTxOnGoing}
-							disabled={!!error || !Boolean(amount)}
+							disabled={!!error || !amount || !BigInt(amount)}
 						>
-							{isDeposit
-								? Boolean(amount)
-									? t("savings.start_earning_interest", { rate: rate / 10_000 })
-									: t("savings.enter_amount_to_add_savings")
-								: !Boolean(amount)
-								? t("savings.enter_withdraw_amount")
-								: t("savings.withdraw_to_my_wallet")}
+							{buttonLabel}
 						</Button>
 					)}
 				</div>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -166,7 +166,7 @@
         "collateralization": "Collateralization",
         "add_collateral": "Add Collateral",
         "remove_collateral": "Remove Collateral",
-        "borrow_more": "Lending more",
+        "borrow_more": "Lend more",
         "pay_back": "Pay back",
         "pay_back_and_close": "Pay back and close position",
         "available_to_borrow": "Available to lend",


### PR DESCRIPTION
## Summary
Fixed the disabled state logic for the borrow more/pay back button to properly disable when no amount is entered or when there's a validation error.

## Problem
The "Borrow More" button was clickable even when the amount field was empty (amount = 0), which doesn't make sense from a UX perspective.

## Solution
Added error state check to the disabled condition:
- Button is now disabled when no amount is entered (`!amount`)
- Button is also disabled when there's a validation error (`Boolean(error)`)

## Test plan
- [x] Verified button is disabled when amount field is empty
- [x] Verified button is disabled when there's a validation error (e.g., exceeding limits)
- [x] Verified button is enabled when valid amount is entered
- [x] Test with both "Borrow More" and "Pay Back" modes