### PR TITLE
feat: Add explicit 503 status handling for Ponder fallback mechanism

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -8,7 +8,7 @@ import { mainnet, polygon, Chain } from "@wagmi/core/chains";
 import axios from "axios";
 import { Address } from "viem";
 
-export type ConfigEnv = { 
+export type ConfigEnv = {
 	landing: string;
 	app: string;
 	api: string;
@@ -42,17 +42,17 @@ export const CONFIG: ConfigEnv = {
 	network: {
 		mainnet: process.env.NEXT_PUBLIC_RPC_URL_MAINNET ?? "https://eth-mainnet.g.alchemy.com/v2",
 		polygon: process.env.NEXT_PUBLIC_RPC_URL_POLYGON ?? "https://polygon-mainnet.g.alchemy.com/v2",
-	}
+	},
 };
 
 const PRINT_CONFIG = (): ConfigEnv => {
-	const printConfig = { ...CONFIG};
+	const printConfig = { ...CONFIG };
 
 	printConfig.wagmiId = TRUNCATE_STRING(printConfig.wagmiId, 5, 5);
 	printConfig.alchemyApiKey = TRUNCATE_STRING(printConfig.alchemyApiKey, 5, 5);
 
 	return printConfig;
-}
+};
 
 const TRUNCATE_STRING = (text: string, startCount: number, endCount: number): string => {
 	if (text.length <= startCount + endCount) return text;
@@ -61,7 +61,7 @@ const TRUNCATE_STRING = (text: string, startCount: number, endCount: number): st
 	const last = text.slice(-endCount);
 
 	return `${first}...${last}`;
-}
+};
 
 // PRINT CONFIGURATION PROFILE
 console.log("YOU ARE USING THIS CONFIG PROFILE:");
@@ -70,12 +70,14 @@ console.log(PRINT_CONFIG());
 // CONFIG CHAIN
 export const CONFIG_CHAIN = (): Chain => {
 	return CONFIG.chain === "polygon" ? polygon : mainnet;
-}
+};
 
 // CONFIG RPC
 export const CONFIG_RPC = (): string => {
-	return CONFIG.chain === "polygon" ? `${CONFIG.network.polygon}/${CONFIG.alchemyApiKey}` : `${CONFIG.network.mainnet}/${CONFIG.alchemyApiKey}`;
-}
+	return CONFIG.chain === "polygon"
+		? `${CONFIG.network.polygon}/${CONFIG.alchemyApiKey}`
+		: `${CONFIG.network.mainnet}/${CONFIG.alchemyApiKey}`;
+};
 
 // Ponder fallback mechanism
 let fallbackUntil: number | null = null;
@@ -89,24 +91,30 @@ function getPonderUrl(): string {
 function activateFallback(): void {
 	if (!fallbackUntil) {
 		fallbackUntil = Date.now() + 10 * 60 * 1000; // 10 minutes
-		console.log('[Ponder] Switching to fallback for 10min:', CONFIG.ponderFallback);
+		console.log("[Ponder] Switching to fallback for 10min:", CONFIG.ponderFallback);
 	}
 }
 
 // PONDER CLIENT
 const errorLink = onError(({ networkError, operation, forward }) => {
-	// Explicitly handle 503 Service Unavailable (Ponder syncing)
-	if (networkError && 'statusCode' in networkError && (networkError as any).statusCode === 503) {
-		console.log('[Ponder] 503 Service Unavailable - Ponder is syncing, switching to fallback');
+	if (!networkError || getPonderUrl() !== CONFIG.ponder) return;
+
+	const is503 =
+		(networkError as any)?.response?.status === 503 ||
+		(networkError as any)?.statusCode === 503 ||
+		(networkError as any)?.result?.status === 503;
+
+	// Handle 503 Service Unavailable (Ponder syncing)
+	if (is503) {
+		console.log("[Ponder] 503 Service Unavailable - Ponder is syncing, switching to fallback");
 		activateFallback();
 		return forward(operation);
 	}
-	
-	// Handle general network errors
-	if (networkError && getPonderUrl() === CONFIG.ponder) {
-		console.log('[Ponder] Network error detected, activating fallback');
-		activateFallback();
-	}
+
+	// Handle other network errors
+	console.log("[Ponder] Network error detected, activating fallback");
+	activateFallback();
+	return forward(operation);
 });
 
 const httpLink = createHttpLink({

--- a/app.config.ts
+++ b/app.config.ts
@@ -94,8 +94,17 @@ function activateFallback(): void {
 }
 
 // PONDER CLIENT
-const errorLink = onError(({ networkError }) => {
+const errorLink = onError(({ networkError, operation, forward }) => {
+	// Explicitly handle 503 Service Unavailable (Ponder syncing)
+	if (networkError && 'statusCode' in networkError && (networkError as any).statusCode === 503) {
+		console.log('[Ponder] 503 Service Unavailable - Ponder is syncing, switching to fallback');
+		activateFallback();
+		return forward(operation);
+	}
+	
+	// Handle general network errors
 	if (networkError && getPonderUrl() === CONFIG.ponder) {
+		console.log('[Ponder] Network error detected, activating fallback');
 		activateFallback();
 	}
 });


### PR DESCRIPTION
## Summary
- Handle 503 Service Unavailable responses when Ponder is syncing
- Add detailed logging for network errors and 503 status codes
- Retry failed operations with fallback URL on 503 errors

## Context
Based on improvements from d-EURO/api PR #58, this PR enhances the existing Ponder fallback mechanism to explicitly handle 503 status codes that occur when Ponder is synchronizing.

## Changes
- Extended error handler to detect and handle 503 responses specifically
- Added logging to distinguish between 503 (Ponder syncing) and general network errors
- Implemented operation retry with `forward(operation)` for 503 errors

## Test plan
- [ ] Verify fallback activates when Ponder returns 503
- [ ] Confirm queries retry automatically with fallback URL
- [ ] Check that logging correctly identifies error types
- [ ] Ensure 10-minute fallback timer still works as expected