### PR TITLE
feat: Auto-fill max available balance when selecting collateral

### DIFF
--- a/components/PageMint/BorrowForm.tsx
+++ b/components/PageMint/BorrowForm.tsx
@@ -173,13 +173,20 @@ export default function PositionCreate({}) {
 		const liqPrice = BigInt(selectedPosition.price);
 
 		setSelectedPosition(selectedPosition);
-		setCollateralAmount(selectedPosition.minimumCollateral);
+		
+		// Use max available balance or minimum collateral, whichever is larger
+		const tokenBalance = balancesByAddress[token.address]?.balanceOf || 0n;
+		const maxAmount = tokenBalance > BigInt(selectedPosition.minimumCollateral) 
+			? tokenBalance.toString() 
+			: selectedPosition.minimumCollateral;
+		
+		setCollateralAmount(maxAmount);
 		setExpirationDate(toDate(selectedPosition.expiration));
 		setLiquidationPrice(liqPrice.toString());
 
 		const loanDetails = getLoanDetailsByCollateralAndStartingLiqPrice(
 			selectedPosition,
-			BigInt(selectedPosition.minimumCollateral),
+			BigInt(maxAmount),
 			liqPrice
 		);
 


### PR DESCRIPTION
## Summary
- Automatically fills the maximum available balance when selecting a collateral asset
- Improves user experience by defaulting to the maximum amount the user can provide

## Changes
- Modified `handleOnSelectedToken` function in `BorrowForm.tsx` to use the maximum available balance from the user's wallet
- Falls back to minimum collateral amount if wallet balance is lower than the required minimum

## Test Plan
- [ ] Select ZCHF as collateral and verify it auto-fills with max wallet balance
- [ ] Verify that if wallet balance < minimum required, it uses minimum instead
- [ ] Test with different collateral types
- [ ] Ensure loan calculations update correctly with the new default amount