### PR TITLE
Fix: Calculate interest based on selected expiration date

### DIFF
--- a/utils/loanCalculations.ts
+++ b/utils/loanCalculations.ts
@@ -16,16 +16,20 @@ export type LoanDetails = {
 
 const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
 
-const getLoanDuration = (position: PositionQuery) => {
-	return Math.max(60 * 60 * 24 * 30, Math.floor((toDate(position.expiration).getTime() - toDate(position.start).getTime()) / 1000));
+const getLoanDuration = (position: PositionQuery, customExpirationDate?: Date) => {
+	const expirationDate = customExpirationDate || toDate(position.expiration);
+	// Use current date as start date for new loans
+	const startDate = new Date();
+	const duration = Math.max(60 * 60 * 24 * 30, Math.floor((expirationDate.getTime() - startDate.getTime()) / 1000));
+	return duration;
 };
 
-const getMiscelaneousLoanDetails = (position: PositionQuery, loanAmount: bigint, collateralAmount: bigint) => {
+const getMiscelaneousLoanDetails = (position: PositionQuery, loanAmount: bigint, collateralAmount: bigint, customExpirationDate?: Date) => {
 	const { fixedAnnualRatePPM, annualInterestPPM, collateralDecimals, reserveContribution } = position;
 
 	const apr = Number((BigInt(fixedAnnualRatePPM) * 100n) / 1_000_000n);
 	const effectiveInterest = (fixedAnnualRatePPM / 10 ** 6 / (1 - reserveContribution / 10 ** 6)) * 100;
-	const selectedPeriod = getLoanDuration(position);
+	const selectedPeriod = getLoanDuration(position, customExpirationDate);
 	const interestUntilExpiration =
 		(BigInt(selectedPeriod) * BigInt(annualInterestPPM) * BigInt(loanAmount)) / BigInt(ONE_YEAR_IN_SECONDS * 1_000_000);
 	const liquidationPriceAtEnd =
@@ -44,7 +48,8 @@ const getMiscelaneousLoanDetails = (position: PositionQuery, loanAmount: bigint,
 export const getLoanDetailsByCollateralAndLiqPrice = (
 	position: PositionQuery,
 	collateralAmount: bigint,
-	liquidationPriceAtEndOfPeriod: bigint
+	liquidationPriceAtEndOfPeriod: bigint,
+	customExpirationDate?: Date
 ): LoanDetails => {
 	const { reserveContribution, collateralDecimals, original, annualInterestPPM } = position;
 
@@ -52,7 +57,7 @@ export const getLoanDetailsByCollateralAndLiqPrice = (
 	const decimalsAdjustment = collateralDecimals === 0 ? BigInt(1e36) : BigInt(1e18);
 	const loanAmountEndOfPeriod = (BigInt(collateralAmount) * BigInt(liquidationPriceAtEndOfPeriod)) / decimalsAdjustment;
 
-	const selectedPeriod = getLoanDuration(position);
+	const selectedPeriod = getLoanDuration(position, customExpirationDate);
 	const loanAmountAtStartOfPeriod =
 		(loanAmountEndOfPeriod * BigInt(ONE_YEAR_IN_SECONDS * 1_000_000)) /
 		(BigInt(ONE_YEAR_IN_SECONDS * 1_000_000) + BigInt(selectedPeriod) * BigInt(annualInterestPPM));
@@ -61,7 +66,7 @@ export const getLoanDetailsByCollateralAndLiqPrice = (
 	const borrowersReserveContribution = (BigInt(reserveContribution) * loanAmountAtStartOfPeriod) / 1_000_000n;
 	const amountToSendToWallet = loanAmountAtStartOfPeriod - borrowersReserveContribution;
 
-	const { effectiveInterest, apr } = getMiscelaneousLoanDetails(position, loanAmountEndOfPeriod, collateralAmount);
+	const { effectiveInterest, apr } = getMiscelaneousLoanDetails(position, loanAmountEndOfPeriod, collateralAmount, customExpirationDate);
 
 	const startingLiquidationPrice =
 		collateralAmount === 0n ? BigInt(0) : (loanAmountAtStartOfPeriod * decimalsAdjustment) / collateralAmount;
@@ -83,7 +88,8 @@ export const getLoanDetailsByCollateralAndLiqPrice = (
 export const getLoanDetailsByCollateralAndStartingLiqPrice = (
 	position: PositionQuery,
 	collateralAmount: bigint,
-	startingLiquidationPrice: bigint
+	startingLiquidationPrice: bigint,
+	customExpirationDate?: Date
 ): LoanDetails => {
 	const { reserveContribution, collateralDecimals, original, annualInterestPPM } = position;
 
@@ -97,7 +103,8 @@ export const getLoanDetailsByCollateralAndStartingLiqPrice = (
 	const { effectiveInterest, apr, interestUntilExpiration } = getMiscelaneousLoanDetails(
 		position,
 		loanAmountStartOfPeriod,
-		collateralAmount
+		collateralAmount,
+		customExpirationDate
 	);
 
 	const liquidationPriceAtEndOfPeriod =
@@ -122,7 +129,8 @@ export const getLoanDetailsByCollateralAndStartingLiqPrice = (
 export const getLoanDetailsByCollateralAndYouGetAmount = (
 	position: PositionQuery,
 	collateralAmount: bigint,
-	youGet: bigint
+	youGet: bigint,
+	customExpirationDate?: Date
 ): LoanDetails => {
 	const { reserveContribution, collateralDecimals, original, annualInterestPPM } = position;
 
@@ -134,14 +142,11 @@ export const getLoanDetailsByCollateralAndYouGetAmount = (
 		collateralAmount === 0n ? BigInt(0) : (loanAmountStartOfPeriod * decimalsAdjustment) / collateralAmount;
 	const borrowersReserveContribution = (BigInt(reserveContribution) * loanAmountStartOfPeriod) / 1_000_000n;
 
-	const selectedPeriod = getLoanDuration(position);
-	const interestCoefficient = (BigInt(selectedPeriod) * BigInt(annualInterestPPM)) / BigInt(ONE_YEAR_IN_SECONDS * 1_000_000);
-	const loanAmountEndOfPeriod = loanAmountStartOfPeriod + interestCoefficient;
-
 	const { effectiveInterest, apr, interestUntilExpiration, liquidationPriceAtEnd } = getMiscelaneousLoanDetails(
 		position,
-		loanAmountEndOfPeriod,
-		collateralAmount
+		loanAmountStartOfPeriod,
+		collateralAmount,
+		customExpirationDate
 	);
 
 	return {


### PR DESCRIPTION
## Summary
- Fixed interest calculation to use the selected expiration date
- Changed start date to use current date instead of position.start  
- Ensures loan details update dynamically when expiration date changes

## Problem
The "Expected interest for the selected period" was calculating incorrectly because:
1. It was using `position.start` (March 2025) instead of the current date
2. This resulted in wrong duration calculations (180 days instead of actual duration)
3. Interest was calculated as 266 dEURO instead of the correct amount

## Solution
- Modified `getLoanDuration()` to use `new Date()` as the start date for new loans
- Added `customExpirationDate` parameter to all loan calculation functions
- Updated all calls to pass the selected expiration date through the calculation chain
- Added handlers to recalculate when expiration date changes

## Test plan
- [x] Select ZCHF as collateral
- [x] Change expiration date to different values
- [x] Verify "Expected interest" updates correctly based on duration
- [x] Verify liquidation prices calculate correctly
- [x] Test with different date ranges (30 days, 90 days, 1 year)