### PR TITLE
Disable Web3Modal analytics to prevent Coinbase 401 errors

### DIFF
--- a/components/Web3Modal.tsx
+++ b/components/Web3Modal.tsx
@@ -12,7 +12,7 @@ if (!CONFIG.wagmiId) throw new Error("Project ID is not defined");
 createWeb3Modal({
 	wagmiConfig: WAGMI_CONFIG,
 	projectId: CONFIG.wagmiId,
-	enableAnalytics: true,
+	enableAnalytics: false,
 	themeMode: "light",
 	themeVariables: {
 		"--w3m-color-mix": "#ffffff",


### PR DESCRIPTION
Disable Web3Modal analytics to prevent console 401 errors from cca-lite.coinbase.com/metrics

## Changes
- Modified components/Web3Modal.tsx: enableAnalytics: true → false

## Test plan
- Build passes successfully
- Wallet connection functionality remains intact  
- No more Coinbase analytics 401 errors in console