### PR TITLE
Fix: Prevent price reset on data updates

### DIFF
--- a/components/PageMint/PriceManageSection.tsx
+++ b/components/PageMint/PriceManageSection.tsx
@@ -97,15 +97,20 @@ export const PriceManageSection = () => {
 		maxPrice = maxByBounds < maxBy2x ? maxByBounds : maxBy2x;
 	}
 
-	// Initialize price on position load
+	// Initialize price only once per position
+	const [initializedPosition, setInitializedPosition] = useState<string | null>(null);
 	useEffect(() => {
 		if (!position) return;
+		
+		// Only initialize if this is a different position or first load
+		if (initializedPosition === position.position) return;
 		
 		if (minPrice > 0 && minPrice <= maxPrice) {
 			const initialPrice = currentPrice > minPrice ? currentPrice : minPrice;
 			setNewPrice(initialPrice.toString());
+			setInitializedPosition(position.position);
 		}
-	}, [currentPrice, minPrice, maxPrice, position]);
+	}, [currentPrice, minPrice, maxPrice, position, initializedPosition]);
 
 	// Validate price input
 	useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixed issue where selected price would reset to minimum after a few seconds
- Price now only initializes once per position and maintains user selection

## Problem
When users selected a price on the manage price page, it would automatically reset to the minimum value after a few seconds. This was caused by the useEffect hook re-initializing the price on every data update (market prices, collateral requirements, etc.).

## Solution
Added position address tracking to ensure price is only set once per position:
- Stores the position address when price is initialized
- Checks if still the same position before re-initializing
- Only resets when switching to a different position
- Preserves user-selected price during background data updates

## Test Plan
- [ ] Select a custom price on the price management page
- [ ] Wait for background data updates (market prices refresh)
- [ ] Verify price stays at selected value
- [ ] Navigate to different position
- [ ] Verify new position initializes with correct price
- [ ] Test with positions that have different collateral types