### PR TITLE
Fix collateral calculation integer division issue

### DIFF
--- a/components/PageMint/CollateralManageSection.tsx
+++ b/components/PageMint/CollateralManageSection.tsx
@@ -98,8 +98,10 @@ export const CollateralManageSection = () => {
 	const allowance = position ? balancesByAddress[position.collateral as Address]?.allowance?.[position.position] || 0n : 0n;
 
 	// Calculate maxToRemove for validation (will be 0 if position is undefined)
+	// Fix: Scale up debt before division to avoid truncation
+	// Price is in 10^(36-collateralDecimals) format, so we scale debt by 10^18 to get collateral in smallest units
 	const maxToRemoveThreshold = position
-		? balanceOf - (debt * 10n ** BigInt(position.collateralDecimals)) / price - BigInt(position.minimumCollateral)
+		? balanceOf - (debt * 10n ** 18n) / price - BigInt(position.minimumCollateral)
 		: 0n;
 	const maxToRemove = debt > 0n ? (maxToRemoveThreshold > 0n ? maxToRemoveThreshold : 0n) : balanceOf;
 


### PR DESCRIPTION
## Summary
- Fixed critical bug in collateral removal calculation that caused integer division truncation
- Positions incorrectly showed collateral as removable when undercollateralized

## Problem
The calculation `(debt * 10^collateralDecimals) / price` would return 0 due to integer division when debt was large and collateralDecimals was small (e.g., WBTC with 8 decimals). This caused the app to show available collateral for removal even when positions needed more collateral than they had.

## Solution
Changed the calculation to `(debt * 10^18) / price` to maintain precision throughout the division operation. This ensures the required collateral is calculated correctly.

## Test Results
Verified with actual blockchain data:
- Undercollateralized positions now correctly show 0 available to remove
- Overcollateralized positions show the correct removable amount
- Positions with no debt allow full collateral removal