### PR TITLE
feat: Improve loan extension UI with interest display

### DIFF
--- a/components/PageMint/ExpirationManageSection.tsx
+++ b/components/PageMint/ExpirationManageSection.tsx
@@ -5,11 +5,11 @@ import { useTranslation } from "next-i18next";
 import { useEffect, useMemo, useState } from "react";
 import { renderErrorTxToast } from "@components/TxToast";
 import { waitForTransactionReceipt } from "wagmi/actions";
-import { ADDRESS, PositionRollerABI } from "@deuro/eurocoin";
+import { ADDRESS, PositionRollerABI, PositionV2ABI } from "@deuro/eurocoin";
 import { useRouter } from "next/router";
 import { writeContract } from "wagmi/actions";
 import { WAGMI_CONFIG } from "../../app.config";
-import { useBlock, useChainId } from "wagmi";
+import { useBlock, useChainId, useReadContracts } from "wagmi";
 import { Address } from "viem/accounts";
 import { getCarryOnQueryParams, shortenAddress, toDate, toQueryString, toTimestamp } from "@utils";
 import { toast } from "react-toastify";
@@ -73,8 +73,30 @@ export const ExpirationManageSection = () => {
 
 	const collateralAllowance = position ? balancesByAddress[position.collateral]?.allowance?.[ADDRESS[chainId].roller] : undefined;
 	const deuroAllowance = position ? balancesByAddress[position.deuro]?.allowance?.[ADDRESS[chainId].roller] : undefined;
+	const deuroBalance = position ? balancesByAddress[position.deuro]?.balance : 0n;
 
 	const url = useContractUrl(position?.position || "");
+	
+	// Fetch principal and debt from smart contract
+	const { data: contractData } = useReadContracts({
+		contracts: position ? [
+			{
+				chainId,
+				address: position.position,
+				abi: PositionV2ABI,
+				functionName: "principal",
+			},
+			{
+				chainId,
+				address: position.position,
+				abi: PositionV2ABI,
+				functionName: "getDebt",
+			},
+		] : [],
+	});
+	
+	const principal = contractData?.[0]?.result || 0n;
+	const currentDebt = contractData?.[1]?.result || 0n;
 
 	useEffect(() => {
 		if (position && expirationDate === undefined) {
@@ -207,6 +229,21 @@ export const ExpirationManageSection = () => {
 
 	const currentExpirationDate = position ? new Date(position.expiration * 1000) : new Date();
 	const daysUntilExpiration = Math.ceil((currentExpirationDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+	
+	// Calculate interest amount to be paid using smart contract data
+	const interest = currentDebt > principal ? currentDebt - principal : 0n;
+	
+	// Check if user has enough dEURO balance to pay interest
+	const hasInsufficientBalance = interest > 0n && BigInt(deuroBalance || 0) < interest;
+	
+	// Format number with commas
+	const formatNumber = (value: bigint, decimals: number = 18): string => {
+		const num = Number(value) / Math.pow(10, decimals);
+		return new Intl.NumberFormat('en-US', { 
+			minimumFractionDigits: 2, 
+			maximumFractionDigits: 2 
+		}).format(num);
+	};
 
 	return (
 		<div className="flex flex-col gap-y-8">
@@ -264,15 +301,43 @@ export const ExpirationManageSection = () => {
 			) : (
 				<>
 					{targetPosition && expirationDate && (
-						<div className="text-sm font-medium text-center">
+						<div className="text-sm font-medium text-center mb-4">
 							Extending by {Math.ceil((expirationDate.getTime() - currentExpirationDate.getTime()) / (1000 * 60 * 60 * 24))} days
+						</div>
+					)}
+					{interest > 0n && (
+						<div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 mb-4">
+							<div className="flex justify-between items-center">
+								<span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+									Outstanding Interest to Pay:
+								</span>
+								<span className="text-lg font-bold text-gray-900 dark:text-gray-100">
+									{formatNumber(interest)} {position.deuroSymbol}
+								</span>
+							</div>
+							<div className="text-xs text-gray-500 dark:text-gray-500 mt-1">
+								Current debt: {formatNumber(currentDebt)} {position.deuroSymbol} 
+								{' '}(Original: {formatNumber(principal)} {position.deuroSymbol})
+							</div>
+							{hasInsufficientBalance && (
+								<div className="mt-2 p-2 bg-red-50 dark:bg-red-900/20 rounded border border-red-200 dark:border-red-800">
+									<div className="text-xs font-medium text-red-600 dark:text-red-400">
+										Insufficient {position.deuroSymbol} balance
+									</div>
+									<div className="text-xs text-red-500 dark:text-red-500 mt-1">
+										You have: {formatNumber(BigInt(deuroBalance || 0))} {position.deuroSymbol}
+										<br />
+										You need: {formatNumber(interest)} {position.deuroSymbol}
+									</div>
+								</div>
+							)}
 						</div>
 					)}
 					<Button
 						className="text-lg leading-snug !font-extrabold"
 						onClick={handleExtendExpiration}
 						isLoading={isTxOnGoing}
-						disabled={isTxOnGoing || !targetPosition}
+						disabled={isTxOnGoing || !targetPosition || hasInsufficientBalance}
 					>
 						{t("mint.extend_roll_borrowing")}
 					</Button>

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -174,7 +174,7 @@
         "available_to_borrow": "Kann ausgeliehen werden",
         "pay_back_amount": "Rückzahlungsbetrag",
         "current_expiration_date": "Aktuelles Ablaufdatum",
-        "extend_roll_borrowing": "Verlängern",
+        "extend_roll_borrowing": "Zinsen bezahlen & Verlängern",
         "extend_roll_borrowing_description": "Die Position muss vor dem Ablaufdatum zurückgezahlt oder verlängert werden. Ein Kreditnehmer bezahlt nur auf die effektiv genutzte Zeit einen Zins, Kredite können somit jederzeit auch frühzeitig vor dem eigentlichen Ablaufdatum zurückgezahlt werden. In der Regel ist es immer sinnvoll die maximal mögliche Kreditlaufzeit zu wählen.",
         "clone": "Klonen",
         "price": "Preis",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -174,7 +174,7 @@
         "available_to_borrow": "Available to lend",
         "pay_back_amount": "Pay back amount",
         "current_expiration_date": "Current expiration date",
-        "extend_roll_borrowing": "Extend Lending",
+        "extend_roll_borrowing": "Pay Interest & Extend Loan",
         "extend_roll_borrowing_description": "The position must either be repaid or extended before the expiry date. A borrower only pays interest on the time actually used, loans can therefore be repaid early at any time before the actual expiry date. It is generally advisable to always choose the maximum possible loan term.",
         "clone": "Clone",
         "price": "Price",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -174,7 +174,7 @@
         "available_to_borrow": "Disponible para pedir prestado",
         "pay_back_amount": "Cantidad a pagar",
         "current_expiration_date": "Fecha de vencimiento actual",
-        "extend_roll_borrowing": "Extender préstamo",
+        "extend_roll_borrowing": "Pagar intereses y extender",
         "extend_roll_borrowing_description": "La posición debe ser reembolsada o extendida antes de la fecha de vencimiento. Un prestatario solo paga intereses por el tiempo efectivamente utilizado, los préstamos pueden por lo tanto ser reembolsados anticipadamente en cualquier momento antes de la fecha de vencimiento real. Generalmente es recomendable elegir siempre el plazo máximo posible del préstamo.",
         "clone": "Clonar",
         "price": "Precio",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -174,7 +174,7 @@
         "available_to_borrow": "Disponible à emprunter",
         "pay_back_amount": "Montant à rembourser",
         "current_expiration_date": "Date d'expiration actuelle",
-        "extend_roll_borrowing": "Prolonger/rouler l'emprunt",
+        "extend_roll_borrowing": "Payer les intérêts et prolonger",
         "extend_roll_borrowing_description": "La position doit être remboursée ou prolongée avant la date d'expiration. Un emprunteur ne paie des intérêts que sur le temps effectivement utilisé, les prêts peuvent donc être remboursés de manière anticipée à tout moment avant la date d'expiration réelle. Il est généralement conseillé de toujours choisir la durée de prêt maximale possible.",
         "clone": "Cloner",
         "price": "Prix",


### PR DESCRIPTION
## Summary
- Added clear display of outstanding interest that must be paid when extending loans
- Implemented wallet balance validation to prevent failed transactions
- Improved user experience with better information and error handling

## Changes
- Display outstanding interest amount prominently in the extension UI
- Show current debt vs original amount for transparency
- Check wallet balance and disable button if insufficient funds
- Updated button text to "Pay Interest & Extend Loan" in all 4 languages
- Reordered UI elements for better flow (extension duration first, then costs)
- Fetch accurate debt data directly from smart contracts

## Test Plan
- [x] Verify interest amount displays correctly
- [x] Test with sufficient balance - button should be enabled
- [x] Test with insufficient balance - button should be disabled with warning
- [x] Verify translations work in all 4 languages
- [x] Check dark mode styling
- [x] Confirm smart contract data fetching works properly