### PR TITLE
feat: Add total savings users count display (#234)

### DIFF
--- a/components/PageSavings/SavingsHistoryCard.tsx
+++ b/components/PageSavings/SavingsHistoryCard.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { useContractUrl } from "@hooks";
+import { useTotalSavingsUsers } from "../../hooks/useTotalSavingsUsers";
 
 enum Timeframe {
 	WEEK = "1W",
@@ -46,6 +47,7 @@ export default function SavingsHistoryCard() {
 	const totalInterest = savingsInfo?.totalInterest;
 	const [timeframe, setTimeframe] = useState<Timeframe>(Timeframe.ALL);
 	const { totalSavings } = useTotalSavingsQuery();
+	const { totalUsers } = useTotalSavingsUsers();
 	const { t } = useTranslation();
 	const startTrades = getStartTimestampByTimeframe(timeframe);
 	const chainId = useChainId();
@@ -178,6 +180,10 @@ export default function SavingsHistoryCard() {
 				<div className="flex flex-row justify-between">
 					<div className="text-sm font-medium leading-relaxed">{t("savings.interest_rate_apr")}</div>
 					<div className="text-sm font-medium leading-tight ">{rate !== undefined ? `${rate / 10_000}%` : "-"}</div>
+				</div>
+				<div className="flex flex-row justify-between">
+					<div className="text-sm font-medium leading-relaxed">{t("savings.total_savers")}</div>
+					<div className="text-sm font-medium leading-tight ">{totalUsers > 0 ? totalUsers.toLocaleString() : "-"}</div>
 				</div>
 				<div className="flex flex-row justify-between">
 					<div className="text-sm font-medium leading-relaxed">{t("savings.total_interest_paid")}</div>

--- a/hooks/useTotalSavingsUsers.tsx
+++ b/hooks/useTotalSavingsUsers.tsx
@@ -1,0 +1,36 @@
+import { gql, useQuery } from "@apollo/client";
+import { ApolloClient, InMemoryCache } from "@apollo/client";
+import { CONFIG } from "../app.config";
+
+// Create a separate Apollo Client for Ponder endpoint
+const ponderClient = new ApolloClient({
+	uri: CONFIG.ponder,
+	cache: new InMemoryCache(),
+});
+
+export const useTotalSavingsUsers = () => {
+	// Query the SavingsStats entity which contains aggregated user count
+	const { data, loading, error } = useQuery(
+		gql`
+			{
+				savingsStats(id: "global") {
+					totalUsers
+					lastUpdated
+				}
+			}
+		`,
+		{
+			client: ponderClient,
+			pollInterval: 60000, // Poll every 60 seconds
+			fetchPolicy: "cache-and-network",
+		}
+	);
+
+	const totalUsers = data?.savingsStats?.totalUsers || 0;
+
+	return {
+		totalUsers,
+		loading,
+		error,
+	};
+};

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -602,6 +602,7 @@
         "total_savings_history": "dEURO Gesamte Ersparnisse",
         "collect_interest": "Einfordern",
         "savings_rate": "Sparzins",
+        "total_savers": "Anzahl Sparer",
         "available_to_deposit": "Verfügbar zum Einzahlen",
         "available_to_withdraw": "Verfügbar zum Auszahlen",
         "current_invest": "Dein aktuelles Invest",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -603,6 +603,7 @@
         "total_savings_history": "dEURO Total Savings",
         "collect_interest": "Collect",
         "savings_rate": "Savings rate",
+        "total_savers": "Total Savers",
         "available_to_deposit": "Available to deposit",
         "available_to_withdraw": "Available to withdraw",
         "current_invest": "Your Current Invest",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -602,6 +602,7 @@
         "total_savings_history": "dEURO Total de Ahorros",
         "collect_interest": "Reclamar",
         "savings_rate": "Tasa de ahorro",
+        "total_savers": "Total de ahorradores",
         "available_to_deposit": "Disponible para depositar",
         "available_to_withdraw": "Disponible para retirar",
         "current_invest": "Tu inversión actual",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -602,6 +602,7 @@
         "total_savings_history": "Épargne totale dEURO",
         "collect_interest": "Récolter",
         "savings_rate": "Taux d'épargne",
+        "total_savers": "Nombre d'épargnants",
         "available_to_deposit": "Disponible pour déposer",
         "available_to_withdraw": "Disponible pour retirer",
         "current_invest": "Votre investissement actuel",


### PR DESCRIPTION
* feat: Add total savings users count display

- Create useTotalSavingsUsers hook using SavingsStats from Ponder API
- Display total users count in SavingsHistoryCard statistics section
- Add translations for 'Total Savers' in all 4 languages (EN/DE/FR/ES)
- Use aggregated data from dev.ponder.deuro.com for scalability

* chore: Remove .claude/settings.local.json file

* fix: Use CONFIG.ponder instead of hardcoded URL in useTotalSavingsUsers hook