### PR TITLE
Remove savings transactions table from dashboard

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -14,7 +14,6 @@ import { TOKEN_SYMBOL } from "@utils";
 import { SOCIAL } from "@utils";
 import GovernancePositionsTable from "@components/PageGovernance/GovernancePositionsTable";
 import GovernanceLeadrateCurrent from "@components/PageGovernance/GovernanceLeadrateCurrent";
-import GovernanceLeadrateTable from "@components/PageSavings/SavingsSavedTable";
 import GovernanceMintersTable from "@components/PageGovernance/GovernanceMintersTable";
 import GovernanceVotersTable from "@components/PageGovernance/GovernanceVotersTable";
 import { SectionTitle } from "@components/SectionTitle";
@@ -137,7 +136,6 @@ export default function Dashboard() {
 								</p>
 							</div>
 							<GovernanceLeadrateCurrent />
-							<GovernanceLeadrateTable />
 						</div>
 
 						<div className="flex flex-col gap-4">


### PR DESCRIPTION
## Summary
- Removed the GovernanceLeadrateTable component that displayed individual transaction history  
- Simplified the governance section while keeping savings overview and leaderboard
- Improved dashboard clarity by removing redundant transaction details

## Changes
- Removed `GovernanceLeadrateTable` import from dashboard.tsx
- Removed `GovernanceLeadrateTable` component from the governance section

## Test plan
- [ ] Verify dashboard loads correctly without the transactions table
- [ ] Confirm savings overview and leaderboard remain functional
- [ ] Check that governance section displays properly