### PR TITLE
Remove savings transactions table from dashboard (#252)

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -14,7 +14,6 @@ import { TOKEN_SYMBOL } from "@utils";
 import { SOCIAL } from "@utils";
 import GovernancePositionsTable from "@components/PageGovernance/GovernancePositionsTable";
 import GovernanceLeadrateCurrent from "@components/PageGovernance/GovernanceLeadrateCurrent";
-import GovernanceLeadrateTable from "@components/PageSavings/SavingsSavedTable";
 import GovernanceMintersTable from "@components/PageGovernance/GovernanceMintersTable";
 import GovernanceVotersTable from "@components/PageGovernance/GovernanceVotersTable";
 import { SectionTitle } from "@components/SectionTitle";
@@ -137,7 +136,6 @@ export default function Dashboard() {
 								</p>
 							</div>
 							<GovernanceLeadrateCurrent />
-							<GovernanceLeadrateTable />
 						</div>
 
 						<div className="flex flex-col gap-4">


### PR DESCRIPTION
- Removed the GovernanceLeadrateTable component that displayed individual transaction history
- Simplified the governance section while keeping savings overview and leaderboard
- Improved dashboard clarity by removing redundant transaction details