### PR TITLE
fix: Add default WAGMI_ID to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ NEXT_PUBLIC_APP_URL=https://app.test.deuro.com
 NEXT_PUBLIC_API_URL=https://dev.api.deuro.com/
 NEXT_PUBLIC_PONDER_URL=https://dev.ponder.deuro.com
 
-NEXT_PUBLIC_WAGMI_ID=...
+NEXT_PUBLIC_WAGMI_ID=1234 # Replace with your WalletConnect Project ID from https://cloud.walletconnect.com/
 NEXT_PUBLIC_ALCHEMY_API_KEY=...
 
 NEXT_PUBLIC_CHAIN_NAME=mainnet


### PR DESCRIPTION
## Summary
Adds a default placeholder value for NEXT_PUBLIC_WAGMI_ID in .env.example to improve developer experience.

## Changes
- Added placeholder value `1234` for `NEXT_PUBLIC_WAGMI_ID`
- Added helpful comment directing developers to WalletConnect Cloud for production IDs

## Motivation
New developers currently encounter an error "Project ID is not defined" when trying to run the app for the first time. This change allows the app to start immediately without requiring WalletConnect account creation, while still making it clear that a real Project ID should be obtained for production use.

## Testing
- [x] App starts without errors using the example configuration
- [x] Comment clearly indicates need for real Project ID in production