### PR TITLE
Replace hardcoded direct transfers with dynamic calculation

### DIFF
--- a/components/PageEquity/EquityNativePoolShareDetailsCard.tsx
+++ b/components/PageEquity/EquityNativePoolShareDetailsCard.tsx
@@ -42,6 +42,7 @@ export default function EquityNativePoolShareDetailsCard() {
 	const profit = earnings?.profit ?? "-";
 	const loss = earnings?.loss ?? "-";
 	const unrealizedProfit = earnings?.unrealizedProfit ?? "-";
+	const directTransfers = earnings?.directTransfers ?? "-";
 	const { trades } = useTradeQuery();
 	const { t } = useTranslation();
 	const startTrades = getStartTimestampByTimeframe(timeframe);
@@ -200,10 +201,9 @@ export default function EquityNativePoolShareDetailsCard() {
 				<div className="flex flex-row justify-between">
 					<div className="text-sm font-medium leading-relaxed">{t("equity.total_income")}</div>
 					<div className="text-sm font-medium leading-tight ">
-						{typeof profit === "number" && typeof unrealizedProfit === "number" && typeof loss === "number"
-							? formatCurrency(profit + unrealizedProfit - loss + 300000, 2, 2) + ` ${TOKEN_SYMBOL}`
+						{typeof profit === "number" && typeof unrealizedProfit === "number" && typeof loss === "number" && typeof directTransfers === "number"
+							? formatCurrency(profit + unrealizedProfit - loss + directTransfers, 2, 2) + ` ${TOKEN_SYMBOL}`
 							: "-"}{" "}
-						{/* 300k was sent directly to Equity contract */}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
This PR replaces the hardcoded 300,000 dEURO value in the Total Income calculation with a dynamic value from the backend API.

## Changes
- Removed hardcoded `+ 300000` constant from Total Income calculation
- Added `directTransfers` field to earnings data
- Updated calculation to use dynamic `directTransfers` value from API
- Removed obsolete comment about hardcoded 300k

## Dependencies
This PR depends on the corresponding API PR: https://github.com/d-EURO/api/pull/65

## Benefits
- Total Income now reflects actual on-chain transfer data
- No manual updates needed when transfers occur
- Fully transparent calculation based on blockchain history

## Testing
- TypeScript compilation successful
- No runtime errors in dev environment
- Backwards compatible (defaults to "-" if data unavailable)