### PR TITLE
Update @deuro/eurocoin to 1.0.17 for new bridge addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@apollo/client": "^3.8.0",
 		"@deuro/api": "^0.3.3",
-		"@deuro/eurocoin": "^1.0.15",
+		"@deuro/eurocoin": "^1.0.17",
 		"@ethersproject/units": "^5.7.0",
 		"@fortawesome/fontawesome-svg-core": "^6.4.2",
 		"@fortawesome/free-brands-svg-icons": "^6.4.2",


### PR DESCRIPTION
## Summary
- Update @deuro/eurocoin package to 1.0.17

## New Bridge Addresses (in package)
| Bridge | Address |
|--------|---------|
| EURS | 0x73f38ca06b27eaefb1612d062d885f58924f5897 |
| VEUR | 0x76d8f514554a4a8e5d6103875f2dd7a67543692b |
| EURe | 0x4dfd460d54854087af195906a2f260aa483a13b1 |

**Note:** This PR should be merged after @deuro/eurocoin 1.0.17 is published to npm.