### PR TITLE
Fix voting power guard nesting order

### DIFF
--- a/components/Guards/GuardToMinVotingPower.tsx
+++ b/components/Guards/GuardToMinVotingPower.tsx
@@ -6,7 +6,6 @@ import Button from "@components/Button";
 interface Props {
 	children?: React.ReactNode;
 	label?: string;
-	disabled?: boolean;
 	buttonClassName?: string;
 }
 

--- a/components/PageGovernance/GovernanceLeadrateCurrent.tsx
+++ b/components/PageGovernance/GovernanceLeadrateCurrent.tsx
@@ -113,12 +113,12 @@ export default function GovernanceLeadrateCurrent({}: Props) {
 					</div>
 				</div>
 
-				<GuardToMinVotingPower buttonClassName="h-full w-full sm:max-w-48 p-4" label={t("dashboard.propose")}>
-					<GuardToAllowedChainBtn
-						buttonClassName="h-full w-full sm:max-w-48 p-4"
-						label={t("dashboard.propose")}
-						disabled={isDisabled || isHidden}
-					>
+				<GuardToAllowedChainBtn
+					buttonClassName="h-full w-full sm:max-w-48 p-4"
+					label={t("dashboard.propose")}
+					disabled={isDisabled || isHidden}
+				>
+					<GuardToMinVotingPower buttonClassName="h-full w-full sm:max-w-48 p-4" label={t("dashboard.propose")}>
 						<Button
 							className="h-full full sm:max-w-48 p-4"
 							disabled={isDisabled || isHidden}
@@ -127,8 +127,8 @@ export default function GovernanceLeadrateCurrent({}: Props) {
 						>
 							{t("dashboard.propose")}
 						</Button>
-					</GuardToAllowedChainBtn>
-				</GuardToMinVotingPower>
+					</GuardToMinVotingPower>
+				</GuardToAllowedChainBtn>
 			</div>
 		</AppCard>
 	);

--- a/components/PageGovernance/GovernanceLeadrateRow.tsx
+++ b/components/PageGovernance/GovernanceLeadrateRow.tsx
@@ -135,8 +135,8 @@ export default function GovernanceLeadrateRow({ headers, info, proposal, current
 				actionCol={
 					currentProposal ? (
 						info.isPending && info.isProposal ? (
-							<GuardToMinVotingPower label="Deny">
-								<GuardToAllowedChainBtn label="Deny" disabled={!info.isPending || !info.isProposal}>
+							<GuardToAllowedChainBtn label="Deny" disabled={!info.isPending || !info.isProposal}>
+								<GuardToMinVotingPower label="Deny">
 									<Button
 										className="h-10"
 										disabled={!info.isPending || !info.isProposal || isHidden}
@@ -145,11 +145,11 @@ export default function GovernanceLeadrateRow({ headers, info, proposal, current
 									>
 										Deny
 									</Button>
-								</GuardToAllowedChainBtn>
-							</GuardToMinVotingPower>
+								</GuardToMinVotingPower>
+							</GuardToAllowedChainBtn>
 						) : (
-							<GuardToMinVotingPower label="Apply">
-								<GuardToAllowedChainBtn label="Apply" disabled={!info.isProposal}>
+							<GuardToAllowedChainBtn label="Apply" disabled={!info.isProposal}>
+								<GuardToMinVotingPower label="Apply">
 									<Button
 										className="h-10"
 										disabled={!info.isProposal || isHidden}
@@ -158,8 +158,8 @@ export default function GovernanceLeadrateRow({ headers, info, proposal, current
 									>
 										Apply
 									</Button>
-								</GuardToAllowedChainBtn>
-							</GuardToMinVotingPower>
+								</GuardToMinVotingPower>
+							</GuardToAllowedChainBtn>
 						)
 					) : (
 						<></>


### PR DESCRIPTION
## Summary
- Fix guard nesting: `GuardToAllowedChainBtn` now wraps `GuardToMinVotingPower` (not the other way around)
- Remove unused `disabled` prop from `GuardToMinVotingPower` interface

## Problem
Disconnected users saw a disabled button with "not enough voting power" tooltip instead of the "Connect Wallet" button, because `GuardToMinVotingPower` was the outermost guard.

## Correct nesting order
```
GuardToAllowedChainBtn  → handles wallet connection + chain
  GuardToMinVotingPower → checks 2% voting power
    Button              → actual action button
```

## Test plan
- [ ] Disconnected wallet → should show "Connect Wallet" button
- [ ] Wrong chain → should show "Change Chain" button
- [ ] Correct chain, < 2% VP → disabled button with voting power tooltip
- [ ] Correct chain, >= 2% VP → normal functional button