### PR TITLE
Remove WAGMI_ID from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,6 @@ NEXT_PUBLIC_APP_URL=https://app.test.deuro.com
 NEXT_PUBLIC_API_URL=https://dev.api.deuro.com/
 NEXT_PUBLIC_PONDER_URL=https://dev.ponder.deuro.com
 
-NEXT_PUBLIC_WAGMI_ID=1234 # Replace with your WalletConnect Project ID from https://cloud.walletconnect.com/
 NEXT_PUBLIC_ALCHEMY_API_KEY=...
 
 NEXT_PUBLIC_CHAIN_NAME=mainnet


### PR DESCRIPTION
## Summary
- Remove `NEXT_PUBLIC_WAGMI_ID` from `.env.example` — no longer needed as env variable since #297 hardcoded it in `app.config.ts`

## Test plan
- [ ] Verify no references to `NEXT_PUBLIC_WAGMI_ID` remain in deployment configs