### PR TITLE
Remove multi-arch build for dApp

### DIFF
--- a/.github/workflows/dapp-dev.yaml
+++ b/.github/workflows/dapp-dev.yaml
@@ -23,9 +23,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -35,7 +32,6 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64,linux/arm64
 
       - name: Install cloudflared
         run: |


### PR DESCRIPTION
Native addons (gyp) are incompatible with QEMU ARM64 emulation on GitHub Actions. Build amd64-only — OrbStack on the server handles emulation.