### PR TITLE
Optimize entrypoint: single sed pass over relevant files only

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,25 +5,16 @@ echo "=========="
 echo "dEURO dApp"
 echo "=========="
 
-# Build a single sed expression for all NEXT_PUBLIC_ env vars
-SED_ARGS=""
-printenv | grep NEXT_PUBLIC_ | while read -r line; do
-  key=$(echo "$line" | cut -d "=" -f1)
-  value=$(echo "$line" | cut -d "=" -f2-)
+# Build sed script for all NEXT_PUBLIC_ env var replacements
+SED_SCRIPT=$(mktemp)
+printenv | grep '^NEXT_PUBLIC_' | while IFS='=' read -r key value; do
+  echo "s|${key}|${value}|g" >> "$SED_SCRIPT"
   echo "Replace: $key"
-  SED_ARGS="$SED_ARGS -e s|$key|$value|g"
-done > /dev/null
-
-# Reconstruct SED_ARGS (subshell workaround)
-SED_ARGS=""
-for line in $(printenv | grep NEXT_PUBLIC_); do
-  key=$(echo "$line" | cut -d "=" -f1)
-  value=$(echo "$line" | cut -d "=" -f2-)
-  SED_ARGS="$SED_ARGS -e s|$key|$value|g"
 done
 
 echo "Replacing env vars in .next build output..."
-find /app/.next/ -type f \( -name '*.js' -o -name '*.json' -o -name '*.html' \) -exec sed -i $SED_ARGS {} +
+find /app/.next/ -type f \( -name '*.js' -o -name '*.json' -o -name '*.html' \) -exec sed -i -f "$SED_SCRIPT" {} +
+rm -f "$SED_SCRIPT"
 echo "Done."
 
 # Execute the container's main process (CMD in Dockerfile)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,15 +5,26 @@ echo "=========="
 echo "dEURO dApp"
 echo "=========="
 
-# Replace env variable placeholders with real values
-printenv | grep NEXT_PUBLIC_ | while read -r line ; do
-  echo "Change env ${line}, please wait ..."
+# Build a single sed expression for all NEXT_PUBLIC_ env vars
+SED_ARGS=""
+printenv | grep NEXT_PUBLIC_ | while read -r line; do
+  key=$(echo "$line" | cut -d "=" -f1)
+  value=$(echo "$line" | cut -d "=" -f2-)
+  echo "Replace: $key"
+  SED_ARGS="$SED_ARGS -e s|$key|$value|g"
+done > /dev/null
 
-  key=$(echo $line | cut -d "=" -f1)
-  value=$(echo $line | cut -d "=" -f2)
-
-  find /app/.next/ -type f -exec sed -i "s|$key|$value|g" {} \;
+# Reconstruct SED_ARGS (subshell workaround)
+SED_ARGS=""
+for line in $(printenv | grep NEXT_PUBLIC_); do
+  key=$(echo "$line" | cut -d "=" -f1)
+  value=$(echo "$line" | cut -d "=" -f2-)
+  SED_ARGS="$SED_ARGS -e s|$key|$value|g"
 done
+
+echo "Replacing env vars in .next build output..."
+find /app/.next/ -type f \( -name '*.js' -o -name '*.json' -o -name '*.html' \) -exec sed -i $SED_ARGS {} +
+echo "Done."
 
 # Execute the container's main process (CMD in Dockerfile)
 exec "$@"


### PR DESCRIPTION
## Problem
The entrypoint replaces NEXT_PUBLIC_* env vars in the .next build output. It runs `find + sed` separately for **each** env variable over **all** files. On emulated amd64 (Apple Silicon), this takes ~12 minutes.

## Fix
- Single `sed` call with all replacements combined (`-e` flags)
- `find -exec ... +` instead of `\;` (batches files, fewer process forks)
- Only process relevant files (`.js`, `.json`, `.html`) instead of all files (images, fonts, etc.)

Expected improvement: ~12 min → ~30 sec.