### PR TITLE
Fix ARM64 builds: use native runners instead of QEMU

### DIFF
--- a/.github/workflows/api-prd.yaml
+++ b/.github/workflows/api-prd.yaml
@@ -6,18 +6,16 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_TAGS: dfxswiss/deuro-dapp:latest
+  DOCKER_IMAGE: dfxswiss/deuro-dapp
+  DOCKER_TAG: latest
   AZURE_RESOURCE_GROUP: rg-dfx-api-prd
   AZURE_CONTAINER_APP: ca-dfx-ded-prd
   DEPLOY_INFO: ${{ github.ref_name }}-${{ github.sha }}
 
 jobs:
-  build-and-deploy:
-    name: Build, test and deploy to PRD
+  build-amd64:
+    name: Build amd64
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: .
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,19 +26,58 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Docker image
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-amd64
+          platforms: linux/amd64
+
+  build-arm64:
+    name: Build arm64
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-arm64
+          platforms: linux/arm64
+
+  deploy:
+    name: Create manifest and deploy
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker manifest create ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }} \
+            ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-amd64 \
+            ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-arm64
+          docker manifest push ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}
 
       - name: Log in to Azure
         uses: azure/login@v2
@@ -51,7 +88,7 @@ jobs:
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
+            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
 
       - name: Logout from Azure
         run: |

--- a/.github/workflows/dapp-dev.yaml
+++ b/.github/workflows/dapp-dev.yaml
@@ -6,12 +6,13 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_TAGS: deurocom/dapp:beta
+  DOCKER_IMAGE: deurocom/dapp
+  DOCKER_TAG: beta
   DEPLOY_SERVICE: deuro-dapp
 
 jobs:
-  build-and-deploy:
-    name: Build and deploy to DEV
+  build-amd64:
+    name: Build amd64
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,19 +24,58 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Docker image
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-amd64
+          platforms: linux/amd64
+
+  build-arm64:
+    name: Build arm64
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-arm64
+          platforms: linux/arm64
+
+  deploy:
+    name: Create manifest and deploy
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker manifest create ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }} \
+            ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-amd64 \
+            ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-arm64
+          docker manifest push ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}
 
       - name: Install cloudflared
         run: |


### PR DESCRIPTION
## Summary

- Replace QEMU cross-compilation with native ARM64 GitHub runners (`ubuntu-24.04-arm`) for both DEV and PRD workflows
- Split each workflow into 3 parallel jobs: `build-amd64`, `build-arm64`, and `deploy` (manifest creation + deployment)
- Remove `docker/setup-qemu-action` dependency entirely

## Problem

QEMU emulation crashes with **SIGILL** (illegal instruction) during the Next.js build step because it cannot emulate certain V8/Node.js ARM64 instructions when running on amd64 GitHub runners. This makes ARM64 Docker image builds unreliable.

## Solution

Use GitHub's native ARM64 runners (`ubuntu-24.04-arm`) to build the ARM64 image natively, eliminating QEMU entirely. Each architecture builds in parallel on its native runner, then a final job creates the multi-arch Docker manifest and deploys.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/dapp-dev.yaml` | Split into 3 jobs, native ARM64 build, manifest creation |
| `.github/workflows/api-prd.yaml` | Same pattern, adapted for PRD (Azure deploy) |

## Test plan

- [ ] DEV workflow: trigger on develop push, verify both amd64 and arm64 images are pushed and manifest is created
- [ ] PRD workflow: trigger on main push, verify multi-arch manifest and Azure deployment
- [ ] Verify `docker manifest inspect deurocom/dapp:beta` shows both architectures