### PR TITLE
Build ARM64-only Docker images for Apple Silicon servers

### DIFF
--- a/.github/workflows/api-prd.yaml
+++ b/.github/workflows/api-prd.yaml
@@ -6,39 +6,12 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_IMAGE: dfxswiss/deuro-dapp
-  DOCKER_TAG: latest
-  AZURE_RESOURCE_GROUP: rg-dfx-api-prd
-  AZURE_CONTAINER_APP: ca-dfx-ded-prd
-  DEPLOY_INFO: ${{ github.ref_name }}-${{ github.sha }}
+  DOCKER_TAGS: dfxswiss/deuro-dapp:latest
+  DEPLOY_SERVICE: deuro-dapp
 
 jobs:
-  build-amd64:
-    name: Build amd64
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-amd64
-          platforms: linux/amd64
-
-  build-arm64:
-    name: Build arm64
+  build-and-deploy:
+    name: Build and deploy to PRD
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
@@ -53,44 +26,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
+      - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-arm64
+          tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/arm64
 
-  deploy:
-    name: Create manifest and deploy
-    runs-on: ubuntu-latest
-    needs: [build-amd64, build-arm64]
-    steps:
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Create and push multi-arch manifest
+      - name: Install cloudflared
         run: |
-          docker manifest create ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }} \
-            ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-amd64 \
-            ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-arm64
-          docker manifest push ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
 
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.DFX_PRD_CREDENTIALS }}
-
-      - name: Update Azure Container App
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
-
-      - name: Logout from Azure
+      - name: Deploy to server
         run: |
-          az logout
-        if: always()
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/dapp-dev.yaml
+++ b/.github/workflows/dapp-dev.yaml
@@ -6,37 +6,12 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_IMAGE: deurocom/dapp
-  DOCKER_TAG: beta
+  DOCKER_TAGS: deurocom/dapp:beta
   DEPLOY_SERVICE: deuro-dapp
 
 jobs:
-  build-amd64:
-    name: Build amd64
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-amd64
-          platforms: linux/amd64
-
-  build-arm64:
-    name: Build arm64
+  build-and-deploy:
+    name: Build and deploy to DEV
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
@@ -51,35 +26,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
+      - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-arm64
+          tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/arm64
-
-  deploy:
-    name: Create manifest and deploy
-    runs-on: ubuntu-latest
-    needs: [build-amd64, build-arm64]
-    steps:
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Create and push multi-arch manifest
-        run: |
-          docker manifest create ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }} \
-            ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-amd64 \
-            ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}-arm64
-          docker manifest push ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}
 
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
       - name: Deploy to server


### PR DESCRIPTION
## Summary

- Remove amd64 build jobs and multi-arch Docker manifest creation
- Consolidate from 3 jobs (build-amd64, build-arm64, deploy) into a single `build-and-deploy` job running natively on `ubuntu-24.04-arm`
- Replace Azure Container App deployment (PRD) with SSH deploy via cloudflared, matching the DEV pattern
- Fix cloudflared download URL to use `cloudflared-linux-arm64` (runner is ARM64)

## Context

Azure is no longer used for deployments. All environments (DEV and PRD) now target ARM64 Apple Silicon servers deployed via SSH through Cloudflare Tunnel. QEMU cross-compilation and multi-arch manifests are no longer needed since only ARM64 images are required.

## Changes

- **`dapp-dev.yaml`**: Single job on ARM64 runner, direct tag push (`deurocom/dapp:beta`), cloudflared arm64 binary
- **`api-prd.yaml`**: Single job on ARM64 runner, direct tag push (`dfxswiss/deuro-dapp:latest`), SSH deploy replacing Azure CLI

## Test plan

- [ ] Verify DEV workflow triggers on push to `develop` and builds ARM64 image
- [ ] Verify PRD workflow triggers on push to `main` and builds ARM64 image
- [ ] Confirm SSH deployment works via cloudflared tunnel on both environments
- [ ] Verify Docker Hub tags are pushed correctly without `-amd64`/`-arm64` suffixes