### PR TITLE
Add VEUR to supported bridges

### DIFF
--- a/hooks/useSupportedBridges.ts
+++ b/hooks/useSupportedBridges.ts
@@ -4,7 +4,7 @@ import { useChainId } from "wagmi";
 
 export enum StablecoinSymbol {
 	EURC = "EURC",
-
+	VEUR = "VEUR",
 	EURS = "EURS",
 	EURR = "EURR",
 	EUROP = "EUROP",
@@ -28,7 +28,11 @@ export const useSupportedBridges = (): SupportedStablecoin[] => {
 			symbol: StablecoinSymbol.EURC,
 			bridgeAddress: ADDRESS[chainId].bridgeEURC,
 		},
-
+		{
+			address: ADDRESS[chainId].veur,
+			symbol: StablecoinSymbol.VEUR,
+			bridgeAddress: ADDRESS[chainId].bridgeVEUR,
+		},
 		{
 			address: ADDRESS[chainId].eurs,
 			symbol: StablecoinSymbol.EURS,


### PR DESCRIPTION
## Summary
- Fügt VEUR als unterstützte Stablecoin-Bridge in `useSupportedBridges` hinzu (nutzt `ADDRESS[chainId].veur` und `ADDRESS[chainId].bridgeVEUR` aus `@deuro/eurocoin`).

## Test plan
- [ ] Bridge-Seite öffnen und prüfen, dass VEUR in der Liste erscheint
- [ ] Bridge-Flow VEUR ↔ dEURO end-to-end testen