### PR TITLE
Fix "Available to lend" stuck at 0 on near-cap positions

### DIFF
--- a/components/PageMint/BorrowedManageSection.tsx
+++ b/components/PageMint/BorrowedManageSection.tsx
@@ -15,7 +15,7 @@ import { PositionV2ABI, PositionV3ABI } from "@deuro/eurocoin";
 import { erc20Abi } from "viem";
 import { useAccount, useChainId } from "wagmi";
 import { useReadContracts } from "wagmi";
-import { getLoanDetailsByCollateralAndStartingLiqPrice, getLoanDetailsByCollateralAndYouGetAmount } from "../../utils/loanCalculations";
+import { calculateNetBorrowHeadroom, getLoanDetailsByCollateralAndYouGetAmount } from "../../utils/loanCalculations";
 import { renderErrorTxToast } from "@components/TxToast";
 import { waitForTransactionReceipt } from "wagmi/actions";
 import { WAGMI_CONFIG } from "../../app.config";
@@ -95,6 +95,12 @@ export const BorrowedManageSection = () => {
 					address: position.position,
 					functionName: "fixedAnnualRatePPM",
 				},
+				{
+					chainId,
+					abi: positionAbi,
+					address: position.position,
+					functionName: "availableForMinting",
+				},
 		] : [],
 	});
 
@@ -107,6 +113,7 @@ export const BorrowedManageSection = () => {
 	const interest = data?.[3]?.result || 0n;
 	const totalDebt = data?.[4]?.result || 0n;
 	const fixedAnnualRatePPM = Number(data?.[5]?.result || 0n);
+	const availableForMinting = data?.[6]?.result || 0n;
 	const amountBorrowed = reserveContribution ? BigInt(principal) - (BigInt(principal) * BigInt(reserveContribution)) / 1_000_000n : 0n;
 	const debt = amountBorrowed + interest;
 	const walletBalance = position ? balancesByAddress?.[position.deuro as Address]?.balanceOf || 0n : 0n;
@@ -115,14 +122,20 @@ export const BorrowedManageSection = () => {
 	const collBalancePosition: number = position ? Math.round((parseInt(position.collateralBalance) / 10 ** position.collateralDecimals) * 100) / 100 : 0;
 	const collTokenPriceMarket = prices[position?.collateral?.toLowerCase() as Address]?.price?.eur || 0;
 	const collTokenPricePosition: number = position ? Math.round((parseInt(position.virtualPrice || position.price) / 10 ** (36 - position.collateralDecimals)) * 100) / 100 : 0;
-	
+
 	const marketValueCollateral: number = collBalancePosition * collTokenPriceMarket;
-	
-	// Calculate max values for validation (will be 0 if position is undefined)
-	const maxAmountByDepositedCollateral = position 
-		? getLoanDetailsByCollateralAndStartingLiqPrice(position, balanceOf, price).amountToSendToWallet
+
+	const maxBeforeAddingMoreCollateral = position
+		? calculateNetBorrowHeadroom({
+				collateralBalance: BigInt(balanceOf),
+				price: BigInt(price),
+				principal: BigInt(principal),
+				interest: BigInt(interest),
+				reservePPM: BigInt(position.reserveContribution),
+				availableForMinting: BigInt(availableForMinting),
+				collateralDecimals: position.collateralDecimals,
+			})
 		: 0n;
-	const maxBeforeAddingMoreCollateral = maxAmountByDepositedCollateral - totalDebt > 0 ? maxAmountByDepositedCollateral - totalDebt : 0n;
 
 	// Error validation for Borrow More
 	useEffect(() => {

--- a/components/PageMint/BorrowedManageSection.tsx
+++ b/components/PageMint/BorrowedManageSection.tsx
@@ -131,25 +131,24 @@ export const BorrowedManageSection = () => {
 				price: BigInt(price),
 				principal: BigInt(principal),
 				interest: BigInt(interest),
-				reservePPM: BigInt(position.reserveContribution),
+				reserveContribution: BigInt(position.reserveContribution),
 				availableForMinting: BigInt(availableForMinting),
 				collateralDecimals: position.collateralDecimals,
 			})
 		: 0n;
 	// `_accrueInterest()` runs inside `_mint` before `_checkCollateral`, so the stored
 	// interest is higher when the TX lands than what RPC read here. Subtract the same
-	// DELAY_MINUTES buffer already used by the repay quoting on line 196 — keeps the
-	// borrow-more max within the on-chain limit across realistic inclusion times.
+	// DELAY_MINUTES buffer the pay-back branch of `handleMaxAmount` already uses — keeps
+	// the borrow-more max within the on-chain limit across realistic inclusion times.
 	const timeBufferWei = calculateTimeBuffer(BigInt(principal), fixedAnnualRatePPM);
 	const maxBeforeAddingMoreCollateral = rawNetHeadroom > timeBufferWei ? rawNetHeadroom - timeBufferWei : 0n;
 
-	// Error validation for Borrow More.
-	// Mirror the repay branch (line 150-160): validate against the *raw* on-chain cap,
-	// not the buffered max. handleMaxAmount pre-discounts by the timeBuffer, so the
-	// user-set amount sits exactly `timeBufferWei` below `rawNetHeadroom`. As `interest`
-	// accrues block-by-block the raw cap drifts down too — but as long as the drift
-	// stays inside the buffer (≤ DELAY_MINUTES of accrual) the input remains valid and
-	// the Lend more button does not flicker disabled.
+	// Validate borrow-more like the pay-back branch below: compare against the raw
+	// on-chain cap, not the buffered max. `handleMaxAmount` pre-discounts by the
+	// timeBuffer, so the user-set amount sits exactly `timeBufferWei` below
+	// `rawNetHeadroom`. As `interest` accrues block-by-block the raw cap drifts down
+	// too — but as long as the drift stays inside the buffer (≤ DELAY_MINUTES of
+	// accrual) the input remains valid and the Lend more button does not flicker.
 	useEffect(() => {
 		if (!position || !isBorrowMore) return;
 

--- a/components/PageMint/BorrowedManageSection.tsx
+++ b/components/PageMint/BorrowedManageSection.tsx
@@ -125,23 +125,23 @@ export const BorrowedManageSection = () => {
 
 	const marketValueCollateral: number = collBalancePosition * collTokenPriceMarket;
 
-	// Project interest forward by the same DELAY_MINUTES window used for repay quoting:
-	// `_accrueInterest()` runs inside `_mint` on-chain, so by the time the TX lands the
-	// stored interest is higher than what RPC read here. Without the buffer the headroom
-	// would round to the on-chain cap and `_checkCollateral` reverts on the few seconds
-	// of drift between read and inclusion.
-	const projectedInterest = BigInt(interest) + calculateTimeBuffer(BigInt(principal), fixedAnnualRatePPM);
-	const maxBeforeAddingMoreCollateral = position
+	const rawNetHeadroom = position
 		? calculateNetBorrowHeadroom({
 				collateralBalance: BigInt(balanceOf),
 				price: BigInt(price),
 				principal: BigInt(principal),
-				interest: projectedInterest,
+				interest: BigInt(interest),
 				reservePPM: BigInt(position.reserveContribution),
 				availableForMinting: BigInt(availableForMinting),
 				collateralDecimals: position.collateralDecimals,
 			})
 		: 0n;
+	// `_accrueInterest()` runs inside `_mint` before `_checkCollateral`, so the stored
+	// interest is higher when the TX lands than what RPC read here. Subtract the same
+	// DELAY_MINUTES buffer already used by the repay quoting on line 196 — keeps the
+	// borrow-more max within the on-chain limit across realistic inclusion times.
+	const timeBufferWei = calculateTimeBuffer(BigInt(principal), fixedAnnualRatePPM);
+	const maxBeforeAddingMoreCollateral = rawNetHeadroom > timeBufferWei ? rawNetHeadroom - timeBufferWei : 0n;
 
 	// Error validation for Borrow More
 	useEffect(() => {

--- a/components/PageMint/BorrowedManageSection.tsx
+++ b/components/PageMint/BorrowedManageSection.tsx
@@ -143,23 +143,29 @@ export const BorrowedManageSection = () => {
 	const timeBufferWei = calculateTimeBuffer(BigInt(principal), fixedAnnualRatePPM);
 	const maxBeforeAddingMoreCollateral = rawNetHeadroom > timeBufferWei ? rawNetHeadroom - timeBufferWei : 0n;
 
-	// Error validation for Borrow More
+	// Error validation for Borrow More.
+	// Mirror the repay branch (line 150-160): validate against the *raw* on-chain cap,
+	// not the buffered max. handleMaxAmount pre-discounts by the timeBuffer, so the
+	// user-set amount sits exactly `timeBufferWei` below `rawNetHeadroom`. As `interest`
+	// accrues block-by-block the raw cap drifts down too — but as long as the drift
+	// stays inside the buffer (≤ DELAY_MINUTES of accrual) the input remains valid and
+	// the Lend more button does not flicker disabled.
 	useEffect(() => {
 		if (!position || !isBorrowMore) return;
 
 		if (!amount) {
 			setError(null);
-		} else if (BigInt(amount) > maxBeforeAddingMoreCollateral) {
+		} else if (BigInt(amount) > rawNetHeadroom) {
 			setError(
 				t("mint.error.minting_limit_exceeded", {
-					amount: formatCurrency(formatUnits(maxBeforeAddingMoreCollateral, 18)),
+					amount: formatCurrency(formatUnits(rawNetHeadroom, 18)),
 					symbol: position.deuroSymbol,
 				})
 			);
 		} else {
 			setError(null);
 		}
-	}, [isBorrowMore, amount, maxBeforeAddingMoreCollateral, position, t]);
+	}, [isBorrowMore, amount, rawNetHeadroom, position, t]);
 
 	// Error validation for Pay Back
 	useEffect(() => {

--- a/components/PageMint/BorrowedManageSection.tsx
+++ b/components/PageMint/BorrowedManageSection.tsx
@@ -125,12 +125,18 @@ export const BorrowedManageSection = () => {
 
 	const marketValueCollateral: number = collBalancePosition * collTokenPriceMarket;
 
+	// Project interest forward by the same DELAY_MINUTES window used for repay quoting:
+	// `_accrueInterest()` runs inside `_mint` on-chain, so by the time the TX lands the
+	// stored interest is higher than what RPC read here. Without the buffer the headroom
+	// would round to the on-chain cap and `_checkCollateral` reverts on the few seconds
+	// of drift between read and inclusion.
+	const projectedInterest = BigInt(interest) + calculateTimeBuffer(BigInt(principal), fixedAnnualRatePPM);
 	const maxBeforeAddingMoreCollateral = position
 		? calculateNetBorrowHeadroom({
 				collateralBalance: BigInt(balanceOf),
 				price: BigInt(price),
 				principal: BigInt(principal),
-				interest: BigInt(interest),
+				interest: projectedInterest,
 				reservePPM: BigInt(position.reserveContribution),
 				availableForMinting: BigInt(availableForMinting),
 				collateralDecimals: position.collateralDecimals,

--- a/tests/borrowHeadroom.spec.ts
+++ b/tests/borrowHeadroom.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import { calculateNetBorrowHeadroom } from '../utils/loanCalculations';
+
+// Live mainnet state of position 0x5AFb27c7aAdc3Ad87BdD4A6De7cc9271F80D566F
+// (eth_call results at 2026-05-16, see RPC verification)
+const liveState = {
+	collateralBalance: 100_000_000n,                                  // 1.0 WBTC (8 dec)
+	price: 510_000_000_000_000_000_000_000_000_000_000n,              // 5.1e32
+	principal: 44_494_748_000_000_000_000_000n,                       // 44 494.748 dEURO
+	interest: 1_485_224_500_000_000_000_000n,                         // ~1485.22 dEURO
+	reservePPM: 100_000n,                                             // 10 %
+	availableForMinting: 1_570_478_740_000_000_000_000_000n,          // 1 570 478.74 dEURO
+	collateralDecimals: 8,
+};
+
+test.describe('calculateNetBorrowHeadroom', () => {
+	test('matches Position._checkCollateral exactly for the live 0x5AFb position', () => {
+		const headroom = calculateNetBorrowHeadroom(liveState);
+		// Expected ≈ 4 369.5023 dEURO net (BigInt floor on the final × usablePPM / 1e6 step).
+		// Rendered to the user as "4 369.50 dEURO" — was stuck at 0 before the fix.
+		expect(headroom).toBe(4_369_502_299_999_999_999_999n);
+		expect(headroom / BigInt(1e16)).toBe(436_950n);
+
+		// Cross-check: minting the gross equivalent must satisfy on-chain _checkCollateral
+		const usablePPM = 1_000_000n - liveState.reservePPM;
+		const grossMint = (headroom * 1_000_000n) / usablePPM;
+		const interestOverhead = (liveState.interest * 1_000_000n + usablePPM - 1n) / usablePPM;
+		const newColReq = liveState.principal + grossMint + interestOverhead;
+		const lhs = liveState.collateralBalance * liveState.price;
+		const rhs = newColReq * BigInt(1e18);
+		expect(lhs >= rhs).toBe(true);                                    // _checkCollateral passes
+		expect(lhs - rhs).toBeLessThan(2n * BigInt(1e18));                // ≤ 1 dEURO_atom slack (BigInt floor)
+	});
+
+	test('returns 0 when collateral value < collateralRequirement (under-water position)', () => {
+		const underWater = { ...liveState, principal: 60_000_000_000_000_000_000_000n };  // 60 000 > 51 000 cap
+		expect(calculateNetBorrowHeadroom(underWater)).toBe(0n);
+	});
+
+	test('is capped by availableForMinting (family-wide limit)', () => {
+		const tinyFamilyCap = { ...liveState, availableForMinting: 1_000_000_000_000_000_000n };  // 1 dEURO
+		const r = calculateNetBorrowHeadroom(tinyFamilyCap);
+		const usablePPM = 1_000_000n - tinyFamilyCap.reservePPM;
+		expect(r).toBe((tinyFamilyCap.availableForMinting * usablePPM) / 1_000_000n);  // 0.9 dEURO net
+	});
+
+	test('returns 0 when reservePPM == 100 % (no usable headroom)', () => {
+		expect(calculateNetBorrowHeadroom({ ...liveState, reservePPM: 1_000_000n })).toBe(0n);
+	});
+
+	test('handles 18-dec collateral (decimalsAdjustment = 1e18)', () => {
+		const wstEth = {
+			collateralBalance: 10n * BigInt(1e18),                        // 10 wstETH
+			price: 3_000n * BigInt(1e18),                                 // 3000 dEURO per whole unit (gross)
+			principal: 20_000n * BigInt(1e18),                            // 20 000 dEURO
+			interest: 0n,
+			reservePPM: 100_000n,                                          // 10 %
+			availableForMinting: 1_000_000n * BigInt(1e18),                // big
+			collateralDecimals: 18,
+		};
+		// collateralValue = 10 × 3000 = 30 000; grossHeadroom = 30 000 − 20 000 = 10 000; net = 9 000
+		expect(calculateNetBorrowHeadroom(wstEth)).toBe(9_000n * BigInt(1e18));
+	});
+});

--- a/tests/borrowHeadroom.spec.ts
+++ b/tests/borrowHeadroom.spec.ts
@@ -1,21 +1,21 @@
-import { test, expect } from '@playwright/test';
-import { calculateNetBorrowHeadroom } from '../utils/loanCalculations';
-import { calculateTimeBuffer } from '../utils/dynamicRepayCalculations';
+import { test, expect } from "@playwright/test";
+import { calculateNetBorrowHeadroom } from "../utils/loanCalculations";
+import { calculateTimeBuffer } from "../utils/dynamicRepayCalculations";
 
 // Live mainnet state of position 0x5AFb27c7aAdc3Ad87BdD4A6De7cc9271F80D566F
 // (eth_call results at 2026-05-16, see RPC verification)
 const liveState = {
-	collateralBalance: 100_000_000n,                                  // 1.0 WBTC (8 dec)
-	price: 510_000_000_000_000_000_000_000_000_000_000n,              // 5.1e32
-	principal: 44_494_748_000_000_000_000_000n,                       // 44 494.748 dEURO
-	interest: 1_485_224_500_000_000_000_000n,                         // ~1485.22 dEURO
-	reservePPM: 100_000n,                                             // 10 %
-	availableForMinting: 1_570_478_740_000_000_000_000_000n,          // 1 570 478.74 dEURO
+	collateralBalance: 100_000_000n, // 1.0 WBTC (8 dec)
+	price: 510_000_000_000_000_000_000_000_000_000_000n, // 5.1e32
+	principal: 44_494_748_000_000_000_000_000n, // 44 494.748 dEURO
+	interest: 1_485_224_500_000_000_000_000n, // ~1485.22 dEURO
+	reservePPM: 100_000n, // 10 %
+	availableForMinting: 1_570_478_740_000_000_000_000_000n, // 1 570 478.74 dEURO
 	collateralDecimals: 8,
 };
 
-test.describe('calculateNetBorrowHeadroom', () => {
-	test('matches Position._checkCollateral exactly for the live 0x5AFb position', () => {
+test.describe("calculateNetBorrowHeadroom", () => {
+	test("matches Position._checkCollateral exactly for the live 0x5AFb position", () => {
 		const headroom = calculateNetBorrowHeadroom(liveState);
 		// Expected ≈ 4 369.5023 dEURO net (BigInt floor on the final × usablePPM / 1e6 step).
 		// Rendered to the user as "4 369.50 dEURO" — was stuck at 0 before the fix.
@@ -29,27 +29,27 @@ test.describe('calculateNetBorrowHeadroom', () => {
 		const newColReq = liveState.principal + grossMint + interestOverhead;
 		const lhs = liveState.collateralBalance * liveState.price;
 		const rhs = newColReq * BigInt(1e18);
-		expect(lhs >= rhs).toBe(true);                                    // _checkCollateral passes
-		expect(lhs - rhs).toBeLessThan(2n * BigInt(1e18));                // ≤ 1 dEURO_atom slack (BigInt floor)
+		expect(lhs >= rhs).toBe(true); // _checkCollateral passes
+		expect(lhs - rhs).toBeLessThan(2n * BigInt(1e18)); // ≤ 1 dEURO_atom slack (BigInt floor)
 	});
 
-	test('returns 0 when collateral value < collateralRequirement (under-water position)', () => {
-		const underWater = { ...liveState, principal: 60_000_000_000_000_000_000_000n };  // 60 000 > 51 000 cap
+	test("returns 0 when collateral value < collateralRequirement (under-water position)", () => {
+		const underWater = { ...liveState, principal: 60_000_000_000_000_000_000_000n }; // 60 000 > 51 000 cap
 		expect(calculateNetBorrowHeadroom(underWater)).toBe(0n);
 	});
 
-	test('is capped by availableForMinting (family-wide limit)', () => {
-		const tinyFamilyCap = { ...liveState, availableForMinting: 1_000_000_000_000_000_000n };  // 1 dEURO
+	test("is capped by availableForMinting (family-wide limit)", () => {
+		const tinyFamilyCap = { ...liveState, availableForMinting: 1_000_000_000_000_000_000n }; // 1 dEURO
 		const r = calculateNetBorrowHeadroom(tinyFamilyCap);
 		const usablePPM = 1_000_000n - tinyFamilyCap.reservePPM;
-		expect(r).toBe((tinyFamilyCap.availableForMinting * usablePPM) / 1_000_000n);  // 0.9 dEURO net
+		expect(r).toBe((tinyFamilyCap.availableForMinting * usablePPM) / 1_000_000n); // 0.9 dEURO net
 	});
 
-	test('returns 0 when reservePPM == 100 % (no usable headroom)', () => {
+	test("returns 0 when reservePPM == 100 % (no usable headroom)", () => {
 		expect(calculateNetBorrowHeadroom({ ...liveState, reservePPM: 1_000_000n })).toBe(0n);
 	});
 
-	test('component-level subtract pattern (raw − calculateTimeBuffer) survives _accrueInterest', () => {
+	test("component-level subtract pattern (raw − calculateTimeBuffer) survives _accrueInterest", () => {
 		// Mirrors BorrowedManageSection: rawNetHeadroom = pure formula, then
 		// safe = raw > buffer ? raw − buffer : 0  (same shape as the repay branch).
 		// Real revert observed in mainnet tx 0x3dc68fbf…: only ~2.66 s of additional
@@ -62,8 +62,8 @@ test.describe('calculateNetBorrowHeadroom', () => {
 		// (well inside the 10-min cushion).
 		const usablePPM = 1_000_000n - liveState.reservePPM;
 		const grossMint = (safe * 1_000_000n) / usablePPM;
-		const interest2minLater = liveState.interest +
-			(liveState.principal * usablePPM * 120_000n * 120n) / (365n * 86400n * 1_000_000n * 1_000_000n);
+		const interest2minLater =
+			liveState.interest + (liveState.principal * usablePPM * 120_000n * 120n) / (365n * 86400n * 1_000_000n * 1_000_000n);
 		const interestOverhead = (interest2minLater * 1_000_000n + usablePPM - 1n) / usablePPM;
 		const newColReq = liveState.principal + grossMint + interestOverhead;
 		const lhs = liveState.collateralBalance * liveState.price;
@@ -72,18 +72,18 @@ test.describe('calculateNetBorrowHeadroom', () => {
 
 		// Sanity: the buffer should cost roughly 1 × calculateTimeBuffer net.
 		expect(raw - safe).toBe(buffer);
-		expect(safe).toBeGreaterThan(4_369n * BigInt(1e18));               // > 4 369.00
-		expect(safe).toBeLessThan(4_369n * BigInt(1e18) + BigInt(5e17));   // < 4 369.50
+		expect(safe).toBeGreaterThan(4_369n * BigInt(1e18)); // > 4 369.00
+		expect(safe).toBeLessThan(4_369n * BigInt(1e18) + BigInt(5e17)); // < 4 369.50
 	});
 
-	test('handles 18-dec collateral (decimalsAdjustment = 1e18)', () => {
+	test("handles 18-dec collateral (decimalsAdjustment = 1e18)", () => {
 		const wstEth = {
-			collateralBalance: 10n * BigInt(1e18),                        // 10 wstETH
-			price: 3_000n * BigInt(1e18),                                 // 3000 dEURO per whole unit (gross)
-			principal: 20_000n * BigInt(1e18),                            // 20 000 dEURO
+			collateralBalance: 10n * BigInt(1e18), // 10 wstETH
+			price: 3_000n * BigInt(1e18), // 3000 dEURO per whole unit (gross)
+			principal: 20_000n * BigInt(1e18), // 20 000 dEURO
 			interest: 0n,
-			reservePPM: 100_000n,                                          // 10 %
-			availableForMinting: 1_000_000n * BigInt(1e18),                // big
+			reservePPM: 100_000n, // 10 %
+			availableForMinting: 1_000_000n * BigInt(1e18), // big
 			collateralDecimals: 18,
 		};
 		// collateralValue = 10 × 3000 = 30 000; grossHeadroom = 30 000 − 20 000 = 10 000; net = 9 000

--- a/tests/borrowHeadroom.spec.ts
+++ b/tests/borrowHeadroom.spec.ts
@@ -49,15 +49,17 @@ test.describe('calculateNetBorrowHeadroom', () => {
 		expect(calculateNetBorrowHeadroom({ ...liveState, reservePPM: 1_000_000n })).toBe(0n);
 	});
 
-	test('with calculateTimeBuffer projection survives Position._accrueInterest at mint time', () => {
-		// Real revert observed (tx 0x3dc68fbf…): mint reverted with InsufficientCollateral
-		// because `_accrueInterest()` runs inside `_mint` and the stored interest grew by
-		// ~2.66 s of drift between RPC read and TX inclusion. The 10-min projection
-		// removes that race entirely.
-		const projected = liveState.interest + calculateTimeBuffer(liveState.principal, 120_000);
-		const safe = calculateNetBorrowHeadroom({ ...liveState, interest: projected });
+	test('component-level subtract pattern (raw − calculateTimeBuffer) survives _accrueInterest', () => {
+		// Mirrors BorrowedManageSection: rawNetHeadroom = pure formula, then
+		// safe = raw > buffer ? raw − buffer : 0  (same shape as the repay branch).
+		// Real revert observed in mainnet tx 0x3dc68fbf…: only ~2.66 s of additional
+		// interest accrual blew the budget. The 10-min buffer removes that race.
+		const raw = calculateNetBorrowHeadroom(liveState);
+		const buffer = calculateTimeBuffer(liveState.principal, 120_000);
+		const safe = raw > buffer ? raw - buffer : 0n;
 
-		// Replay on-chain check with 2 minutes of additional accrued interest beyond our buffer cushion
+		// Replay on-chain check at TX-time with 2 minutes of additional interest
+		// (well inside the 10-min cushion).
 		const usablePPM = 1_000_000n - liveState.reservePPM;
 		const grossMint = (safe * 1_000_000n) / usablePPM;
 		const interest2minLater = liveState.interest +
@@ -68,9 +70,10 @@ test.describe('calculateNetBorrowHeadroom', () => {
 		const rhs = newColReq * BigInt(1e18);
 		expect(lhs >= rhs).toBe(true);
 
-		// And the displayed value is still nonzero / near the unbuffered cap
-		expect(safe).toBeGreaterThan(4_300n * BigInt(1e18));
-		expect(safe).toBeLessThan(4_369n * BigInt(1e18) + BigInt(6e17));   // < 4 369.60
+		// Sanity: the buffer should cost roughly 1 × calculateTimeBuffer net.
+		expect(raw - safe).toBe(buffer);
+		expect(safe).toBeGreaterThan(4_369n * BigInt(1e18));               // > 4 369.00
+		expect(safe).toBeLessThan(4_369n * BigInt(1e18) + BigInt(5e17));   // < 4 369.50
 	});
 
 	test('handles 18-dec collateral (decimalsAdjustment = 1e18)', () => {

--- a/tests/borrowHeadroom.spec.ts
+++ b/tests/borrowHeadroom.spec.ts
@@ -90,3 +90,25 @@ test.describe("calculateNetBorrowHeadroom", () => {
 		expect(calculateNetBorrowHeadroom(wstEth)).toBe(9_000n * BigInt(1e18));
 	});
 });
+
+test.describe("BorrowedManageSection validation race", () => {
+	test("user input set from max-button stays valid while raw cap drifts within the buffer", () => {
+		// At t0 the max button writes (rawNet − buffer) into the input.
+		// Validation compares against rawNet (not the buffered max), so drift inside
+		// the buffer window must NOT mark the input invalid.
+		const rawNetT0 = calculateNetBorrowHeadroom(liveState);
+		const buffer = calculateTimeBuffer(liveState.principal, 120_000);
+		const maxButtonValue = rawNetT0 > buffer ? rawNetT0 - buffer : 0n;
+		const amount = maxButtonValue;
+
+		// Simulate the page idling for 5 minutes — half the 10-min buffer window.
+		const usablePPM = 1_000_000n - liveState.reservePPM;
+		const driftSeconds = 300n;
+		const driftedInterest =
+			liveState.interest + (liveState.principal * usablePPM * 120_000n * driftSeconds) / (365n * 86400n * 1_000_000n * 1_000_000n);
+		const rawNetT1 = calculateNetBorrowHeadroom({ ...liveState, interest: driftedInterest });
+
+		expect(amount).toBeLessThanOrEqual(rawNetT1); // validation: amount > rawNet ? error : ok
+		expect(rawNetT1).toBeLessThan(rawNetT0); // sanity: cap really did drift down
+	});
+});

--- a/tests/borrowHeadroom.spec.ts
+++ b/tests/borrowHeadroom.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { calculateNetBorrowHeadroom } from '../utils/loanCalculations';
+import { calculateTimeBuffer } from '../utils/dynamicRepayCalculations';
 
 // Live mainnet state of position 0x5AFb27c7aAdc3Ad87BdD4A6De7cc9271F80D566F
 // (eth_call results at 2026-05-16, see RPC verification)
@@ -46,6 +47,30 @@ test.describe('calculateNetBorrowHeadroom', () => {
 
 	test('returns 0 when reservePPM == 100 % (no usable headroom)', () => {
 		expect(calculateNetBorrowHeadroom({ ...liveState, reservePPM: 1_000_000n })).toBe(0n);
+	});
+
+	test('with calculateTimeBuffer projection survives Position._accrueInterest at mint time', () => {
+		// Real revert observed (tx 0x3dc68fbf…): mint reverted with InsufficientCollateral
+		// because `_accrueInterest()` runs inside `_mint` and the stored interest grew by
+		// ~2.66 s of drift between RPC read and TX inclusion. The 10-min projection
+		// removes that race entirely.
+		const projected = liveState.interest + calculateTimeBuffer(liveState.principal, 120_000);
+		const safe = calculateNetBorrowHeadroom({ ...liveState, interest: projected });
+
+		// Replay on-chain check with 2 minutes of additional accrued interest beyond our buffer cushion
+		const usablePPM = 1_000_000n - liveState.reservePPM;
+		const grossMint = (safe * 1_000_000n) / usablePPM;
+		const interest2minLater = liveState.interest +
+			(liveState.principal * usablePPM * 120_000n * 120n) / (365n * 86400n * 1_000_000n * 1_000_000n);
+		const interestOverhead = (interest2minLater * 1_000_000n + usablePPM - 1n) / usablePPM;
+		const newColReq = liveState.principal + grossMint + interestOverhead;
+		const lhs = liveState.collateralBalance * liveState.price;
+		const rhs = newColReq * BigInt(1e18);
+		expect(lhs >= rhs).toBe(true);
+
+		// And the displayed value is still nonzero / near the unbuffered cap
+		expect(safe).toBeGreaterThan(4_300n * BigInt(1e18));
+		expect(safe).toBeLessThan(4_369n * BigInt(1e18) + BigInt(6e17));   // < 4 369.60
 	});
 
 	test('handles 18-dec collateral (decimalsAdjustment = 1e18)', () => {

--- a/tests/borrowHeadroom.spec.ts
+++ b/tests/borrowHeadroom.spec.ts
@@ -9,7 +9,7 @@ const liveState = {
 	price: 510_000_000_000_000_000_000_000_000_000_000n, // 5.1e32
 	principal: 44_494_748_000_000_000_000_000n, // 44 494.748 dEURO
 	interest: 1_485_224_500_000_000_000_000n, // ~1485.22 dEURO
-	reservePPM: 100_000n, // 10 %
+	reserveContribution: 100_000n, // 10 %
 	availableForMinting: 1_570_478_740_000_000_000_000_000n, // 1 570 478.74 dEURO
 	collateralDecimals: 8,
 };
@@ -23,7 +23,7 @@ test.describe("calculateNetBorrowHeadroom", () => {
 		expect(headroom / BigInt(1e16)).toBe(436_950n);
 
 		// Cross-check: minting the gross equivalent must satisfy on-chain _checkCollateral
-		const usablePPM = 1_000_000n - liveState.reservePPM;
+		const usablePPM = 1_000_000n - liveState.reserveContribution;
 		const grossMint = (headroom * 1_000_000n) / usablePPM;
 		const interestOverhead = (liveState.interest * 1_000_000n + usablePPM - 1n) / usablePPM;
 		const newColReq = liveState.principal + grossMint + interestOverhead;
@@ -41,12 +41,12 @@ test.describe("calculateNetBorrowHeadroom", () => {
 	test("is capped by availableForMinting (family-wide limit)", () => {
 		const tinyFamilyCap = { ...liveState, availableForMinting: 1_000_000_000_000_000_000n }; // 1 dEURO
 		const r = calculateNetBorrowHeadroom(tinyFamilyCap);
-		const usablePPM = 1_000_000n - tinyFamilyCap.reservePPM;
+		const usablePPM = 1_000_000n - tinyFamilyCap.reserveContribution;
 		expect(r).toBe((tinyFamilyCap.availableForMinting * usablePPM) / 1_000_000n); // 0.9 dEURO net
 	});
 
-	test("returns 0 when reservePPM == 100 % (no usable headroom)", () => {
-		expect(calculateNetBorrowHeadroom({ ...liveState, reservePPM: 1_000_000n })).toBe(0n);
+	test("returns 0 when reserveContribution == 100 % (no usable headroom)", () => {
+		expect(calculateNetBorrowHeadroom({ ...liveState, reserveContribution: 1_000_000n })).toBe(0n);
 	});
 
 	test("component-level subtract pattern (raw − calculateTimeBuffer) survives _accrueInterest", () => {
@@ -60,7 +60,7 @@ test.describe("calculateNetBorrowHeadroom", () => {
 
 		// Replay on-chain check at TX-time with 2 minutes of additional interest
 		// (well inside the 10-min cushion).
-		const usablePPM = 1_000_000n - liveState.reservePPM;
+		const usablePPM = 1_000_000n - liveState.reserveContribution;
 		const grossMint = (safe * 1_000_000n) / usablePPM;
 		const interest2minLater =
 			liveState.interest + (liveState.principal * usablePPM * 120_000n * 120n) / (365n * 86400n * 1_000_000n * 1_000_000n);
@@ -82,27 +82,25 @@ test.describe("calculateNetBorrowHeadroom", () => {
 			price: 3_000n * BigInt(1e18), // 3000 dEURO per whole unit (gross)
 			principal: 20_000n * BigInt(1e18), // 20 000 dEURO
 			interest: 0n,
-			reservePPM: 100_000n, // 10 %
+			reserveContribution: 100_000n, // 10 %
 			availableForMinting: 1_000_000n * BigInt(1e18), // big
 			collateralDecimals: 18,
 		};
 		// collateralValue = 10 × 3000 = 30 000; grossHeadroom = 30 000 − 20 000 = 10 000; net = 9 000
 		expect(calculateNetBorrowHeadroom(wstEth)).toBe(9_000n * BigInt(1e18));
 	});
-});
 
-test.describe("BorrowedManageSection validation race", () => {
-	test("user input set from max-button stays valid while raw cap drifts within the buffer", () => {
-		// At t0 the max button writes (rawNet − buffer) into the input.
-		// Validation compares against rawNet (not the buffered max), so drift inside
-		// the buffer window must NOT mark the input invalid.
+	test("max-button value stays valid while the raw cap drifts within the buffer window", () => {
+		// Regression for the validation race in BorrowedManageSection: at t0 the max
+		// button writes (rawNet − buffer) into the input, and validation compares
+		// against rawNet (not the buffered max). Drift inside the buffer window must
+		// NOT flip the input invalid (which would grey out the Lend more button).
 		const rawNetT0 = calculateNetBorrowHeadroom(liveState);
 		const buffer = calculateTimeBuffer(liveState.principal, 120_000);
-		const maxButtonValue = rawNetT0 > buffer ? rawNetT0 - buffer : 0n;
-		const amount = maxButtonValue;
+		const amount = rawNetT0 > buffer ? rawNetT0 - buffer : 0n;
 
 		// Simulate the page idling for 5 minutes — half the 10-min buffer window.
-		const usablePPM = 1_000_000n - liveState.reservePPM;
+		const usablePPM = 1_000_000n - liveState.reserveContribution;
 		const driftSeconds = 300n;
 		const driftedInterest =
 			liveState.interest + (liveState.principal * usablePPM * 120_000n * driftSeconds) / (365n * 86400n * 1_000_000n * 1_000_000n);

--- a/utils/loanCalculations.ts
+++ b/utils/loanCalculations.ts
@@ -159,3 +159,34 @@ export const getLoanDetailsByCollateralAndYouGetAmount = (
 		startingLiquidationPrice,
 	};
 };
+
+/**
+ * Maximum additional net dEURO payout a borrower can mint on an existing position
+ * before tripping Position._checkCollateral on-chain (MintingHubV3/Position.sol).
+ *
+ * Mirrors:
+ *   _getCollateralRequirement = principal + ceilDivPPM(_calculateInterest(), reservePPM)
+ *   _checkCollateral:  collateral × price ≥ collateralRequirement × 1e18
+ *
+ * Result is the *net* amount that lands in the wallet, i.e. after the reserve cut.
+ */
+export const calculateNetBorrowHeadroom = (input: {
+	collateralBalance: bigint;
+	price: bigint;
+	principal: bigint;
+	interest: bigint;
+	reservePPM: bigint;
+	availableForMinting: bigint;
+	collateralDecimals: number;
+}): bigint => {
+	const { collateralBalance, price, principal, interest, reservePPM, availableForMinting, collateralDecimals } = input;
+	const decimalsAdjustment = collateralDecimals === 0 ? BigInt(1e36) : BigInt(1e18);
+	const collateralValue = (collateralBalance * price) / decimalsAdjustment;
+	const usablePPM = 1_000_000n - reservePPM;
+	if (usablePPM <= 0n) return 0n;
+	const interestOverhead = (interest * 1_000_000n + usablePPM - 1n) / usablePPM;
+	const collateralRequirement = principal + interestOverhead;
+	const grossHeadroomByCollateral = collateralValue > collateralRequirement ? collateralValue - collateralRequirement : 0n;
+	const grossHeadroom = grossHeadroomByCollateral < availableForMinting ? grossHeadroomByCollateral : availableForMinting;
+	return (grossHeadroom * usablePPM) / 1_000_000n;
+};

--- a/utils/loanCalculations.ts
+++ b/utils/loanCalculations.ts
@@ -170,7 +170,7 @@ export const getLoanDetailsByCollateralAndYouGetAmount = (
  *
  * Result is the *net* amount that lands in the wallet, i.e. after the reserve cut.
  */
-export const calculateNetBorrowHeadroom = (input: {
+export const calculateNetBorrowHeadroom = (params: {
 	collateralBalance: bigint;
 	price: bigint;
 	principal: bigint;
@@ -179,7 +179,7 @@ export const calculateNetBorrowHeadroom = (input: {
 	availableForMinting: bigint;
 	collateralDecimals: number;
 }): bigint => {
-	const { collateralBalance, price, principal, interest, reservePPM, availableForMinting, collateralDecimals } = input;
+	const { collateralBalance, price, principal, interest, reservePPM, availableForMinting, collateralDecimals } = params;
 	const decimalsAdjustment = collateralDecimals === 0 ? BigInt(1e36) : BigInt(1e18);
 	const collateralValue = (collateralBalance * price) / decimalsAdjustment;
 	const usablePPM = 1_000_000n - reservePPM;

--- a/utils/loanCalculations.ts
+++ b/utils/loanCalculations.ts
@@ -165,7 +165,7 @@ export const getLoanDetailsByCollateralAndYouGetAmount = (
  * before tripping Position._checkCollateral on-chain (MintingHubV3/Position.sol).
  *
  * Mirrors:
- *   _getCollateralRequirement = principal + ceilDivPPM(_calculateInterest(), reservePPM)
+ *   _getCollateralRequirement = principal + ceilDivPPM(_calculateInterest(), reserveContribution)
  *   _checkCollateral:  collateral × price ≥ collateralRequirement × 1e18
  *
  * Result is the *net* amount that lands in the wallet, i.e. after the reserve cut.
@@ -175,14 +175,14 @@ export const calculateNetBorrowHeadroom = (params: {
 	price: bigint;
 	principal: bigint;
 	interest: bigint;
-	reservePPM: bigint;
+	reserveContribution: bigint;
 	availableForMinting: bigint;
 	collateralDecimals: number;
 }): bigint => {
-	const { collateralBalance, price, principal, interest, reservePPM, availableForMinting, collateralDecimals } = params;
+	const { collateralBalance, price, principal, interest, reserveContribution, availableForMinting, collateralDecimals } = params;
 	const decimalsAdjustment = collateralDecimals === 0 ? BigInt(1e36) : BigInt(1e18);
 	const collateralValue = (collateralBalance * price) / decimalsAdjustment;
-	const usablePPM = 1_000_000n - reservePPM;
+	const usablePPM = 1_000_000n - reserveContribution;
 	if (usablePPM <= 0n) return 0n;
 	const interestOverhead = (interest * 1_000_000n + usablePPM - 1n) / usablePPM;
 	const collateralRequirement = principal + interestOverhead;


### PR DESCRIPTION
## Summary

- The borrow-more headroom in `BorrowedManageSection` mixed gross and net amounts (`amountToSendToWallet − totalDebt`) and clamped to zero on near-cap positions, even though `Position._mint` would still accept the mint on-chain. The "Lend more" button became unusable.
- Replace the formula with a faithful port of `Position._checkCollateral` / `_getCollateralRequirement` from `MintingHubV3/Position.sol`:
  - `collateral × price ≥ (principal + ΔX + ceilDivPPM(interest, reserveContribution)) × 1e18`
  - capped by `Position.availableForMinting()` (family-wide limit)
  - discounted by `(1 − reserveContribution/1e6)` to match the *net* UI input
- Apply the same `calculateTimeBuffer` (DELAY_MINUTES = 10) the pay-back branch of `handleMaxAmount` already uses, so the displayed max stays mintable across realistic inclusion times. `_accrueInterest()` runs inside `_mint` and grows `interest` between the RPC read and TX inclusion — without the buffer, even a few seconds of drift trip `_checkCollateral` and revert the mint.
- Validate the user input against the raw on-chain cap (not the buffered max), matching the pay-back branch which validates against `walletBalance` / `debt` directly. Without this, the button would flicker disabled on every block as `interest` accrues and the buffered max drifts below the static input value.
- Extract the formula as the pure utility `calculateNetBorrowHeadroom()` in `utils/loanCalculations.ts` so it can be unit-tested in isolation.

## Concrete impact

Seeded with the live state of the WBTC position `0x5AFb27c7aAdc3Ad87BdD4A6De7cc9271F80D566F`:

| | before | after |
|---|---:|---:|
| Available to lend | `0 dEURO` | `~4 369.40 dEURO` |
| "Lend more" button | disabled | enabled, stays clickable across block refetches |
| Mint TX | reverts with `InsufficientCollateral` | succeeds |

The 0.10 dEURO gap between the unbuffered formula (4 369.50) and the shipped value (4 369.40) is exactly the 10-min interest cushion that prevents the race observed in mainnet tx `0x3dc68fbf34f02d6bdc7d2e036973fdd74c0f79d50697a5b773e1698ade3c8b54` (revert from ~2.66 s of additional accrual).

## Code shape

The new max-amount and validation lines are now structurally identical to the existing repay branch in `BorrowedManageSection`:

```ts
// borrow-more (new)
const timeBufferWei = calculateTimeBuffer(BigInt(principal), fixedAnnualRatePPM);
const maxBeforeAddingMoreCollateral = rawNetHeadroom > timeBufferWei ? rawNetHeadroom - timeBufferWei : 0n;
// validation: BigInt(amount) > rawNetHeadroom  (raw cap, not buffered max)

// pay-back (already on develop)
const timeBufferWei = calculateTimeBuffer(principal, fixedAnnualRatePPM);
const maxFromWallet = walletBalance > timeBufferWei ? walletBalance - timeBufferWei : 0n;
// validation: BigInt(amount) > walletBalance  (raw cap, not buffered max)
```

Same helper, same `DELAY_MINUTES = 10`, same `x > buf ? x − buf : 0n` shape, same validate-against-raw rule — one buffer pattern across both branches of the manage section.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx next build` (prod) — clean
- [x] `npx prettier --check` on changed files — clean
- [x] `tests/borrowHeadroom.spec.ts` — 7 / 7 passing
  - matches `Position._checkCollateral` to the atto-dEURO for the live `0x5AFb…` state
  - returns 0 on an under-water position
  - capped correctly by `availableForMinting`
  - returns 0 when `reserveContribution == 100 %`
  - `raw − calculateTimeBuffer` survives `_accrueInterest` with 2 min of additional drift
  - handles 18-dec collateral (`decimalsAdjustment = 1e18`)
  - max-button value stays valid while the raw cap drifts within the buffer window (validation race regression)
- [ ] Manual: load `/mint/<position>/manage/borrowed` on a near-cap position with a connected wallet and confirm the displayed "Available to lend" matches the on-chain max-mintable amount; the Lend more button stays clickable through block refetches.