### PR TITLE
Lower the collateralization warning threshold to 105% for WFPS

### DIFF
--- a/components/PageMonitoring/MonitoringRow.tsx
+++ b/components/PageMonitoring/MonitoringRow.tsx
@@ -10,7 +10,7 @@ import { useRouter } from "next/router";
 import { useContractUrl } from "@hooks";
 import Button from "@components/Button";
 import { useTranslation } from "next-i18next";
-import { getCarryOnQueryParams, TOKEN_SYMBOL, toQueryString } from "@utils";
+import { getCarryOnQueryParams, getCollateralizationWarningThreshold, TOKEN_SYMBOL, toQueryString } from "@utils";
 
 interface Props {
 	headers: string[];
@@ -36,6 +36,8 @@ export default function MonitoringRow({ headers, position, tab }: Props) {
 	const marketValueCollateral: number = collBalancePosition * collTokenPriceMarket;
 	const positionValueCollateral: number = collBalancePosition * collTokenPricePosition;
 	const collateralizationPercentage: number = Math.round((marketValueCollateral / positionValueCollateral) * 10000) / 100;
+	const isCollateralizationAtRisk: boolean =
+		collateralizationPercentage < getCollateralizationWarningThreshold(position.collateralSymbol);
 
 	const digits: number = position.collateralDecimals;
 	const positionChallenges = challenges?.map?.[position.position.toLowerCase() as Address] ?? [];
@@ -101,7 +103,7 @@ export default function MonitoringRow({ headers, position, tab }: Props) {
 
 			{/* Coll. */}
 			<div className="flex flex-col gap-2">
-				<div className={`col-span-2 text-md ${collateralizationPercentage < 110 ? "text-text-warning font-bold" : ""}`}>
+				<div className={`col-span-2 text-md ${isCollateralizationAtRisk ? "text-text-warning font-bold" : ""}`}>
 					{!isNaN(collateralizationPercentage) ? formatCurrency(collateralizationPercentage) : "-.--"}%
 				</div>
 			</div>

--- a/components/PageMypositions/MypositionsRow.tsx
+++ b/components/PageMypositions/MypositionsRow.tsx
@@ -7,7 +7,7 @@ import { formatCurrency } from "../../utils/format";
 import MyPositionsDisplayCollateral from "./MyPositionsDisplayCollateral";
 import { useRouter as useNavigate } from "next/navigation";
 import Button from "@components/Button";
-import { TOKEN_SYMBOL } from "@utils";
+import { getCollateralizationWarningThreshold, TOKEN_SYMBOL } from "@utils";
 
 interface Props {
 	headers: string[];
@@ -44,6 +44,7 @@ export default function MypositionsRow({ headers, subHeaders, position, tab }: P
 
 	const liquidationDEURO: number = parseInt(position.price) / 10 ** (36 - position.collateralDecimals);
 	const liquidationPct: number = (balanceDEURO / (liquidationDEURO * balance)) * 100;
+	const isLiquidationAtRisk: boolean = liquidationPct < getCollateralizationWarningThreshold(position.collateralSymbol);
 
 	const positionChallenges = challenges?.map?.[position.position.toLowerCase() as Address] ?? [];
 	const positionChallengesActive = positionChallenges.filter((ch: ChallengesQueryItem) => ch.status == "Active") ?? [];
@@ -160,7 +161,7 @@ export default function MypositionsRow({ headers, subHeaders, position, tab }: P
 
 			{/* Liquidation */}
 			<div className="flex flex-col">
-				<span className={liquidationPct < 110 ? `text-md font-bold text-text-warning` : "text-md "}>
+				<span className={isLiquidationAtRisk ? `text-md font-bold text-text-warning` : "text-md "}>
 					{formatCurrency(liquidationDEURO, 2, 2)} {TOKEN_SYMBOL}
 				</span>
 				<span className="text-sm text-text-subheader">{formatCurrency(collTokenPrice / deuroPrice, 2, 2)} {TOKEN_SYMBOL}</span>

--- a/utils/constant.ts
+++ b/utils/constant.ts
@@ -30,6 +30,17 @@ export const POOL_SHARE_TOKEN_SYMBOL = "DEPS";
 
 export const NATIVE_POOL_SHARE_TOKEN_SYMBOL = "nDEPS";
 
+// Collateralization ratio (in %) below which a position is highlighted as at risk.
+export const COLLATERALIZATION_WARNING_THRESHOLD = 110;
+
+// Collateral specific overrides of the warning threshold, keyed by collateral symbol.
+export const COLLATERALIZATION_WARNING_THRESHOLD_OVERRIDES: Record<string, number | undefined> = {
+	WFPS: 105,
+};
+
+export const getCollateralizationWarningThreshold = (collateralSymbol?: string): number =>
+	COLLATERALIZATION_WARNING_THRESHOLD_OVERRIDES[collateralSymbol?.toUpperCase() ?? ""] ?? COLLATERALIZATION_WARNING_THRESHOLD;
+
 // For managing frontend codes
 export const MARKETING_PARAM_NAME = "ref";
 


### PR DESCRIPTION
## What

The collateralization ratio displayed in the position tables is highlighted in the warning colour once it drops below a fixed 110%, regardless of the collateral. For WFPS the highlight should only kick in below **105%**.

## Why

WFPS is a slow-moving, thinly traded collateral. At 110% its positions were permanently rendered as at risk even though they sit comfortably above the level where challenging them becomes attractive, which makes the warning colour meaningless for the collaterals where it actually matters.

## How

- `utils/constant.ts`: the threshold is no longer a magic number in the components. `COLLATERALIZATION_WARNING_THRESHOLD` holds the default (110), `COLLATERALIZATION_WARNING_THRESHOLD_OVERRIDES` holds per-collateral overrides (`WFPS: 105`), and `getCollateralizationWarningThreshold(collateralSymbol)` resolves the two. The symbol lookup is case-insensitive.
- `components/PageMonitoring/MonitoringRow.tsx` (Monitoring table, "Coll." column) and `components/PageMypositions/MypositionsRow.tsx` (My positions table, "Liquidation" column) now resolve the threshold per position instead of comparing against 110.

Behaviour for every collateral other than WFPS is unchanged. Purely a display change — no contract calls, no calculations touched.

## Verification

- `tsc --noEmit` passes.
- `prettier --check` reports no new findings on the touched files (all three were already non-conforming on `develop`; the added lines are prettier-clean).
- The dashboard "My Borrow" table renders the same ratio but has never coloured it, so it is untouched.
