### PR TITLE
Remove VEUR from supported bridges

### DIFF
--- a/hooks/useSupportedBridges.ts
+++ b/hooks/useSupportedBridges.ts
@@ -4,7 +4,6 @@ import { useChainId } from "wagmi";
 
 export enum StablecoinSymbol {
 	EURC = "EURC",
-	VEUR = "VEUR",
 	EURS = "EURS",
 	EURR = "EURR",
 	EUROP = "EUROP",
@@ -27,11 +26,6 @@ export const useSupportedBridges = (): SupportedStablecoin[] => {
 			address: ADDRESS[chainId].eurc,
 			symbol: StablecoinSymbol.EURC,
 			bridgeAddress: ADDRESS[chainId].bridgeEURC,
-		},
-		{
-			address: ADDRESS[chainId].veur,
-			symbol: StablecoinSymbol.VEUR,
-			bridgeAddress: ADDRESS[chainId].bridgeVEUR,
 		},
 		{
 			address: ADDRESS[chainId].eurs,


### PR DESCRIPTION
## What

Removes VEUR from the supported stablecoin bridges again — the `StablecoinSymbol.VEUR` enum member and its entry in `useSupportedBridges()`.

## Why

VEUR is no longer supported as a bridge input. It was taken out in #320 and re-added in #323; this restores the state #320 established.

## How

`hooks/useSupportedBridges.ts` is the only file that referenced VEUR — `grep -rni veur` over the source tree returns nothing after this change, so no other call site is affected. The bridge list keeps its order (`EURC, EURS, EURR, EUROP, EURI, EURE, EURA`).

One deliberate difference from a plain revert of #323: #320 left blank-line placeholders behind where the enum member and the list entry had been, and #323 filled them back in. This removal drops both without reintroducing those placeholders, so the file stays clean.

`public/coin/veur.svg` is left in place, matching what #320 did — the logo is served by symbol and removing the asset is a separate call.

## Verification

- `tsc --noEmit` passes.
- `prettier --check hooks/useSupportedBridges.ts` passes cleanly.
