### PR TITLE
b8a6465f - Fix nDEPS mint/redeem reverting from missing slippage tolerance

### DIFF
--- a/components/PageEquity/InteractionStablecoinAndNativePS.tsx
+++ b/components/PageEquity/InteractionStablecoinAndNativePS.tsx
@@ -23,6 +23,10 @@ import { TokenBalance } from "../../hooks/useWalletBalances";
 import { TokenInteractionSide } from "./EquityInteractionCard";
 import { RootState } from "../../redux/redux.store";
 import { useSelector } from "react-redux";
+
+const SLIPPAGE_BPS = 50n; // 0.5% slippage tolerance on the expected output amount
+const applySlippage = (expected: bigint): bigint => expected - (expected * SLIPPAGE_BPS) / 10000n;
+
 interface Props {
 	openSelector: (tokenInteractionSide: TokenInteractionSide) => void;
 	selectedFromToken: TokenBalance | undefined;
@@ -123,7 +127,7 @@ export default function InteractionStablecoinAndNativePS({
 				address: ADDRESS[chainId].frontendGateway,
 				abi: FrontendGatewayV2ABI,
 				functionName: "invest",
-				args: [amount, result, frontendCode],
+				args: [amount, applySlippage(result), frontendCode],
 			});
 
 			const toastContent = [
@@ -248,7 +252,7 @@ export default function InteractionStablecoinAndNativePS({
 				address: ADDRESS[chainId].frontendGateway,
 				abi: FrontendGatewayV2ABI,
 				functionName: "redeem",
-				args: [account, amount, deuroResult, frontendCode],
+				args: [account, amount, applySlippage(deuroResult), frontendCode],
 			});
 
 			const toastContent = [


### PR DESCRIPTION
## Problem

Minting nDEPS (and redeeming) through the app frontend fails: the wallet reports the transaction will revert during gas estimation, so users effectively cannot mint.

## Root cause

`handleInvest` / `handleRedeem` pass the exact `calculateShares` / `calculateProceeds` result as the on-chain minimum (`expectedShares` / `expectedProceeds`), leaving zero slippage margin. The Equity contract enforces `require(shares >= expectedShares)`. Because the quote depends on `dEURO.equity()`, any minimal increase of protocol equity between quoting and signing pushes the achievable amount just below the quoted minimum and the transaction reverts.

Verified on-chain against the live FrontendGateway path: passing the exact `calculateShares` succeeds, while `calculateShares + 1 wei` reverts — the margin is exactly zero. It is aggravated by the current diluted pool state, where equity moves more frequently.

## Fix

Apply a 0.5% (50 bps) tolerance to the expected output amount used as the on-chain minimum, while keeping the displayed quote unchanged.

Scope is limited to the dEURO ↔ nDEPS interaction (`invest` + `redeem`), which are the only exit paths carrying a min-output argument. The other paths are unaffected because they have no such parameter: the savings redeem uses ERC4626 `redeem(shares, receiver, owner)`, and `unwrapAndSell(amount, frontendCode)` takes no expected-out argument.

## Verification

- `npx tsc --noEmit` passes.
- Production build (`next build`) passes.
